### PR TITLE
Feat: internal module that contains helper functionality and DX improvement

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-npx lint-staged
+npx lint-staged --config ./lint-staged.config.js

--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -1,0 +1,8 @@
+export default {
+  '!(*test).js': [
+    () => 'npm run typecheck',
+    'npm run lint',
+    'npm run prettier',
+  ],
+  '*test.js': ['npm run lint', 'npm run prettier'],
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
       "devDependencies": {
         "@types/chai": "^4.3.3",
         "@types/mocha": "^9.1.1",
+        "@types/node": "^18.7.18",
         "@typescript-eslint/eslint-plugin": "^5.36.2",
         "@typescript-eslint/parser": "^5.36.2",
         "chai": "^4.3.6",
@@ -791,6 +792,12 @@
       "version": "9.1.1",
       "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-9.1.1.tgz",
       "integrity": "sha512-Z61JK7DKDtdKTWwLeElSEBcWGRLY8g95ic5FoQqI9CMx0ns/Ghep3B4DfcEimiKMvtamNVULVNKEsiwV3aQmXw==",
+      "dev": true
+    },
+    "node_modules/@types/node": {
+      "version": "18.7.18",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.18.tgz",
+      "integrity": "sha512-m+6nTEOadJZuTPkKR/SYK3A2d7FZrgElol9UP1Kae90VVU4a6mxnPuLiIW1m4Cq4gZ/nWb9GrdVXJCoCazDAbg==",
       "dev": true
     },
     "node_modules/@types/normalize-package-data": {
@@ -5640,6 +5647,12 @@
       "version": "9.1.1",
       "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-9.1.1.tgz",
       "integrity": "sha512-Z61JK7DKDtdKTWwLeElSEBcWGRLY8g95ic5FoQqI9CMx0ns/Ghep3B4DfcEimiKMvtamNVULVNKEsiwV3aQmXw==",
+      "dev": true
+    },
+    "@types/node": {
+      "version": "18.7.18",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.18.tgz",
+      "integrity": "sha512-m+6nTEOadJZuTPkKR/SYK3A2d7FZrgElol9UP1Kae90VVU4a6mxnPuLiIW1m4Cq4gZ/nWb9GrdVXJCoCazDAbg==",
       "dev": true
     },
     "@types/normalize-package-data": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "lint": "eslint --cache",
     "lint:packages": "npm run lint \"packages/**/*.js\"",
     "prettier": "prettier --write",
-    "typecheck": "tsc --noEmit --skipLibCheck --allowJs --checkJs --strict",
+    "typecheck": "tsc",
     "test": "mocha \"packages/**/*.test.js\"",
     "test:watch": "mocha \"packages/**/*.test.js\" --parallel --watch",
     "test:coverage": "nyc npm run test"
@@ -28,6 +28,7 @@
   "devDependencies": {
     "@types/chai": "^4.3.3",
     "@types/mocha": "^9.1.1",
+    "@types/node": "^18.7.18",
     "@typescript-eslint/eslint-plugin": "^5.36.2",
     "@typescript-eslint/parser": "^5.36.2",
     "chai": "^4.3.6",
@@ -51,21 +52,5 @@
   },
   "dependencies": {
     "node-fetch": "3.2.10"
-  },
-  "lint-staged": {
-    "*.d.ts": [
-      "npm run typecheck",
-      "npm run lint",
-      "npm run prettier"
-    ],
-    "!(*test).js": [
-      "npm run typecheck",
-      "npm run lint",
-      "npm run prettier"
-    ],
-    "*test.js": [
-      "npm run lint",
-      "npm run prettier"
-    ]
   }
 }

--- a/packages/internal/config/config.js
+++ b/packages/internal/config/config.js
@@ -1,0 +1,53 @@
+/**
+ * @typedef API
+ * @property {string} base_url - The base URL for inLive API.
+ * @property {string} version - The version of the API
+ */
+
+/**
+ * @type {API}
+ */
+const api = {
+  base_url: 'https://api.inlive.app',
+  version: 'v1',
+}
+
+/**
+ * @typedef ICEServers
+ * @property {string} urls - The server URL
+ * @property {string} [username] - The username that will be used to connect with the server
+ * @property {string} [credential] - The credential that will be used to connect with the server
+ */
+
+/**
+ * @typedef WebRTC
+ * @property {Array<ICEServers>} servers - Servers used to allow connection with the peers
+ */
+
+/**
+ * @type {WebRTC}
+ */
+const webrtc = {
+  servers: [
+    { urls: 'stun:stun.l.google.com:19302' },
+    {
+      urls: 'turn:34.101.121.241:3478',
+      username: 'username',
+      credential: 'password',
+    },
+  ],
+}
+
+/**
+ * @typedef Channel
+ * @property {string} base_url - The base URL for the inLive stream channel
+ */
+
+/**
+ * @type {Channel}
+ */
+const channel = {
+  base_url: 'https://channel.inlive.app',
+}
+
+export { api, webrtc, channel }

--- a/packages/internal/fetch-http/fetch-http.js
+++ b/packages/internal/fetch-http/fetch-http.js
@@ -1,0 +1,83 @@
+/**
+ * @typedef BaseConfig
+ * @property {string} url - The API endpoint URL
+ * @property {string} [token] - The bearer token for authorization purpose
+ * @property {'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE'} [method] - The HTTP request methods used
+ * @property {object} [body] - The request body which contains the data that will be transmitted in an HTTP request
+ * @property {object} [options] - Option fetch parameter
+ */
+
+/**
+ * @type {BaseConfig}
+ */
+const baseConfig = {
+  url: '',
+  token: '',
+  method: 'GET',
+  body: undefined,
+  options: undefined,
+}
+
+/**
+ * A HTTP client module to fetch a request in the browser and server sides
+ *
+ * @function
+ * @param {BaseConfig} config A set of key/value parameter configuration
+ * @returns {Promise<any>} Returns a promise with the actual response data
+ * @throws {Error}
+ */
+export const fetchHttp = async (config = baseConfig) => {
+  const { url, token, method, body, options: fetchOptions } = config
+
+  if (url.trim().length === 0) {
+    throw new Error('Please provide the url')
+  }
+
+  const options = {
+    method: method || 'GET',
+    headers: {
+      Authorization: token ? `Bearer ${token}` : '',
+      'Content-Type': 'application/json',
+    },
+    body:
+      typeof body === 'object' && method !== 'GET'
+        ? JSON.stringify(body)
+        : undefined,
+    ...fetchOptions,
+  }
+
+  let fetchHttpRequest
+
+  if (typeof window === 'undefined' || !window) {
+    /**
+     * Server side fetch HTTP request
+     *
+     * @param {string} url - The API endpoint URL
+     * @param {object} options - Option fetch parameter
+     * @returns {Promise<any>} Returns a promise with the actual response data
+     */
+    fetchHttpRequest = (url, options) => {
+      return import('node-fetch').then(({ default: fetch }) => {
+        return fetch(url, options)
+      })
+    }
+  } else {
+    /**
+     * Client side fetch HTTP request
+     *
+     * @param {string} url - The API endpoint URL
+     * @param {object} options - Option fetch parameter
+     * @returns {Promise<any>} Returns a promise with the actual response data
+     */
+    fetchHttpRequest = (url, options) => {
+      return window.fetch(url, options)
+    }
+  }
+
+  const response = await fetchHttpRequest(url, options)
+  const json = await response.json()
+
+  return response.ok && json.code >= 200 && json.code < 300
+    ? Promise.resolve(json)
+    : Promise.reject(json)
+}

--- a/packages/internal/fetch-http/fetch-http.test.js
+++ b/packages/internal/fetch-http/fetch-http.test.js
@@ -1,0 +1,10 @@
+import { expect } from 'chai'
+import { fetchHttp } from './fetch-http.js'
+
+describe('Test cases for the fetchHttp() function', function () {
+  describe('Basic test', function () {
+    it('should be a function', function () {
+      expect(fetchHttp).to.be.a('function')
+    })
+  })
+})

--- a/packages/internal/index.js
+++ b/packages/internal/index.js
@@ -1,0 +1,1 @@
+export * as Internal from './modules.js'

--- a/packages/internal/modules.js
+++ b/packages/internal/modules.js
@@ -1,0 +1,2 @@
+export { fetchHttp } from './fetch-http/fetch-http.js'
+export * as config from './config/config.js'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,8 @@
     "allowJs": true,
     "checkJs": true,
     "noEmit": true,
-    "strict": true
+    "strict": true,
+    "lib": ["es2018", "dom"]
   },
   "include": ["./packages/**/*.js"],
   "exclude": ["node_modules", "dist", "**/*.test.js", "./*.js"]


### PR DESCRIPTION
# Description
This PR will add internal modules which are reusable helper modules that will be used by other modules. This PR will also add DX improvement that relates with type checking

**Changelogs:**
- Added a new fetch HTTP helper module to help interact with the fetch API both in the client and server sides.
- We will add more test cases for fetch HTTP helper in the future
- Added a config module which actually a module to place non-sensitive static configuration for other SDK modules
- Added es2018 and dom lib type definitions inside the tsconfig.json file to help type checking purposes. Dom lib type definitions are important for logic to check or interact with the window/document object
- Added `@types/node` type definition for node.js
- Moved the lint-staged configuration to the separate configuration file called lint-staged.config.js. This update was to fix the `tsc` TypeScript type checking command that could not detect the tsconfig.json configuration file at the root directory automatically when running with lint-staged.
- The type checking for .d.ts file was removed because we will focus writing the type anotation using JSDoc