### PR TITLE
Revision: Refactor Init Module To Be Able To Use InstanceOf

### DIFF
--- a/packages/app/init/init.js
+++ b/packages/app/init/init.js
@@ -13,11 +13,11 @@ function InitializationInstance(config) {
 }
 
 /**
- * Initialize an initialization object
+ * Initialize an initialization instance
  *
  * @function
  * @param {Config} config - A set of key/value parameter configuration
- * @returns {object} InitializationObject that contains config object of api_key
+ * @returns {object} InitializationInstance that contains config object of api_key
  * @throws {Error}
  */
 const init = (config) => {

--- a/packages/app/init/init.js
+++ b/packages/app/init/init.js
@@ -4,18 +4,20 @@
  */
 
 /**
- * @typedef InitializationObject
- * @property {object} config - The key/value configuration inside the initialization object
- * @property {string} config.api_key - A string of key that will be used to access inLive protected API
- * @property {string} name - The name of initialization object instance
+ * A function to create object
+ *
+ * @param {Config} config -- being passed from init module parameter
  */
+function initializeConfig(config) {
+  this.config = config
+}
 
 /**
  * Initialize an initialization object
  *
  * @function
  * @param {Config} config - A set of key/value parameter configuration
- * @returns {InitializationObject} InitializationObject
+ * @returns {object} InitializationObject that contains config object of api_key
  * @throws {Error}
  */
 const init = (config) => {
@@ -32,12 +34,7 @@ const init = (config) => {
       'Failed to process because the API key field is an empty string. Please provide an API key.'
     )
   } else {
-    return {
-      config: {
-        api_key: config.api_key,
-      },
-      name: 'default',
-    }
+    return new initializeConfig(config)
   }
 }
 

--- a/packages/app/init/init.js
+++ b/packages/app/init/init.js
@@ -8,7 +8,7 @@
  *
  * @param {Config} config -- being passed from init module parameter
  */
-function initializeConfig(config) {
+function InitializationInstance(config) {
   this.config = config
 }
 
@@ -34,7 +34,7 @@ const init = (config) => {
       'Failed to process because the API key field is an empty string. Please provide an API key.'
     )
   } else {
-    return new initializeConfig(config)
+    return new InitializationInstance(config)
   }
 }
 

--- a/packages/app/init/init.test.js
+++ b/packages/app/init/init.test.js
@@ -65,7 +65,6 @@ describe('Test cases for the init() function', function () {
     it('should returns a success response with api key data inside the object', function () {
       expect(init({ api_key: 'any api key' })).to.be.an('object')
       expect(init({ api_key: 'any api key' })).to.have.property('config')
-      expect(init({ api_key: 'any api key' })).to.have.property('name')
       expect(init({ api_key: 'any api key' })).to.have.deep.nested.property(
         'config.api_key'
       )


### PR DESCRIPTION
**Description**
Because the return object from `init` module will be used as `eg. initObject` on other modules, for the easier application, we can use [instanceOf](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/instanceof) javascript for checking the condition. However, we need to refactor `init` module code so we can check it with `instanceOf`.

**Implementation**
- I add `initializeConfig` function so the `init` module will return as an object to be able to check with `instanceOf` javascript.
- Erase `name` properties from `init` module return (also omit it on the testing file)