### PR TITLE
feat: end stream module

### DIFF
--- a/packages/stream/end-stream/end-stream.js
+++ b/packages/stream/end-stream/end-stream.js
@@ -1,0 +1,92 @@
+import { InitializationInstance } from '../../app/init/init.js'
+import { Internal } from '../../internal/index.js'
+import { getStream } from '../get-stream/get-stream.js'
+
+/**
+ * @typedef Config
+ * @property {number} stream_id - The ID of the stream
+ */
+
+/**
+ * End and stop a stream
+ *
+ * @param {object} initInstance - The initialization instance received from the init() function
+ * @param {Config} config - Key / value configuration
+ */
+const endStream = async (initInstance, config) => {
+  /**
+   * ======================================================
+   *  Validations
+   * ======================================================
+   */
+
+  if (!(initInstance instanceof InitializationInstance)) {
+    throw new TypeError(
+      `Failed to process because initialization is not valid. Please provide required initialization argument which is the initialization instance returned by the init() function`
+    )
+  } else if (!config || config.stream_id === undefined) {
+    throw new Error(
+      'Failed to process because the stream ID is not provided. Please provide the stream ID!'
+    )
+  } else if (typeof config.stream_id !== 'number') {
+    throw new TypeError(
+      'Failed to process because the stream ID is not in a number format. The stream ID must be in a number format'
+    )
+  }
+
+  /**
+   * ======================================================
+   *  Variables
+   * ======================================================
+   */
+
+  const {
+    config: { api_key },
+  } = initInstance
+
+  const { fetchHttp, config: baseConfig, webrtc } = Internal
+
+  const { stream_id } = config
+
+  const clientState = webrtc.getClientState()
+
+  /**
+   * ======================================================
+   *  Executions
+   * ======================================================
+   */
+
+  if (clientState === 'live') {
+    const baseUrl = `${baseConfig.api.base_url}/${baseConfig.api.version}`
+    try {
+      const response = await fetchHttp({
+        url: `${baseUrl}/streams/${stream_id}/end`,
+        token: api_key,
+        method: 'POST',
+        body: {},
+      })
+
+      const latestStreamData = await getStream(stream_id)
+
+      const successResponse = {
+        status: {
+          code: response.code || null,
+          type: 'success',
+          message: 'Successfully ended the stream',
+        },
+        data: latestStreamData.data || null,
+      }
+
+      return successResponse
+    } catch (error) {
+      console.error(error)
+      throw error
+    }
+  } else {
+    throw new Error(
+      `Failed to end the stream because the stream was not currently running. Please make sure you have a stream that is currently running`
+    )
+  }
+}
+
+export { endStream }


### PR DESCRIPTION
# Description
This is the implementation of the end stream module based on this issue https://github.com/inlivedev/inlive-js-sdk/issues/6

- This module consists of a function to end / stop a running live stream by hitting the `/streams/{streamId}/end` endpoint.
- The `endStream` function needs two arguments, initialization instance and the config argument where the stream ID will be put.
- Before the function executes an HTTP request to the end endpoint, it will check whether the client state is already running a stream or currently is live.
- After a stream has been successfully ended / stopped. The function will return the latest updated stream data.
- The test file for this module hasn't been created. We will add the test file next time.