### PR TITLE
feat: internal module - channel

### DIFF
--- a/packages/internal/channel/channel.js
+++ b/packages/internal/channel/channel.js
@@ -93,10 +93,10 @@ const channel = (() => {
   }
 
   return {
-    subscribe,
-    onOpen,
     onError,
     onMessage,
+    onOpen,
+    subscribe,
   }
 })()
 

--- a/packages/internal/channel/channel.js
+++ b/packages/internal/channel/channel.js
@@ -41,7 +41,7 @@ const channel = (() => {
       )
     } else if (typeof stream_id !== 'number') {
       throw new TypeError(
-        ' Failed to process - Invalid stream ID format. Stream ID must use a number format'
+        'Failed to process - Invalid stream ID format. Stream ID must use a number format'
       )
     }
 

--- a/packages/internal/channel/channel.js
+++ b/packages/internal/channel/channel.js
@@ -1,0 +1,105 @@
+/**
+ * @typedef Connection
+ * @property {EventTarget | undefined} client - The client interface that manages the connection between the client and server channels
+ */
+
+const channel = (() => {
+  /**
+   * ======================================================
+   *  Variables
+   * ======================================================
+   */
+
+  /**
+   * @type {Connection}
+   */
+  const connection = {
+    client: undefined,
+  }
+
+  /**
+   * ======================================================
+   *  Functions
+   * ======================================================
+   */
+
+  /**
+   *
+   * @param {EventTarget} clientInterface - The client interface that manages the connection between the client and server channels
+   * @returns {EventTarget | void} Returns the client interface
+   */
+  const subscribe = (clientInterface) => {
+    if (
+      !(connection.client instanceof EventTarget) &&
+      clientInterface instanceof EventTarget
+    ) {
+      connection.client = clientInterface
+      return connection.client
+    }
+
+    return
+  }
+
+  /**
+   *
+   * @param {Function} callback - A callback function
+   */
+  const onOpen = (callback) => {
+    if (
+      connection.client instanceof EventTarget &&
+      callback instanceof Function
+    ) {
+      connection.client.addEventListener('open', (event) => {
+        callback(event)
+      })
+    }
+  }
+
+  /**
+   *
+   * @param {Function} callback - A callback function
+   */
+  const onError = (callback) => {
+    if (
+      connection.client instanceof EventTarget &&
+      callback instanceof Function
+    ) {
+      connection.client.addEventListener('error', (event) => {
+        callback(event)
+      })
+    }
+  }
+
+  /**
+   *
+   * @param {Function} callback - A callback function
+   */
+  const onMessage = (callback) => {
+    if (
+      connection.client instanceof EventTarget &&
+      callback instanceof Function
+    ) {
+      connection.client.addEventListener(
+        'message',
+        /** @param {any} event - The Event Object with additional data property */
+        (event) => {
+          if (event.data) {
+            const data = JSON.parse(event.data)
+            callback(data)
+          }
+        }
+      )
+    }
+  }
+
+  return {
+    subscribe,
+    onOpen,
+    onError,
+    onMessage,
+  }
+})()
+
+Object.freeze(channel)
+
+export { channel }

--- a/packages/internal/channel/channel.js
+++ b/packages/internal/channel/channel.js
@@ -40,7 +40,9 @@ const channel = (() => {
         'Failed to process - A stream ID is required to subscribe to the channel'
       )
     } else if (typeof stream_id !== 'number') {
-      throw new TypeError(' Failed to process - Invalid stream ID format')
+      throw new TypeError(
+        ' Failed to process - Invalid stream ID format. Stream ID must use a number format'
+      )
     }
 
     if (!(connection.client instanceof WebSocket)) {


### PR DESCRIPTION
# Description
This channel module implementation is based on this issue https://github.com/inlivedev/inlive-js-sdk/issues/16. The channel module is responsible to manage the connection between the client and the channel server either using WebSocket or SSE.


How to use this module:
```js
channel.subscribe(streamId)

channel.onMessage((data) => {
// handle message event here
})

channel.onError((event) => {
// handle error
})

channel.unsubscribe()
```

This module is implemented using these patterns:
   - [Singleton pattern](https://rajeshnaroth.medium.com/singletons-in-javascript-and-es6-26f276a21df8): the behaviour of this module is a singleton by default which has the advantage of making the value and state always the same when the module is shared and imported into the other modules.
   - [Revealing module pattern](https://dev.to/nas5w/the-revealing-module-pattern-in-javascript-15a8): this module is implemented using a revealing module pattern to encapsulate the data and state and only reveal methods needed by other modules.

The test file for this module hasn't been created. We will add the test file next time.