### PR TITLE
feat: pre publish configuration setup and fix type check errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@types/chai": "^4.3.3",
         "@types/mocha": "^9.1.1",
         "@types/node": "^18.7.18",
+        "@types/node-fetch": "^2.6.2",
         "@typescript-eslint/eslint-plugin": "^5.36.2",
         "@typescript-eslint/parser": "^5.36.2",
         "chai": "^4.3.6",
@@ -802,6 +803,16 @@
       "integrity": "sha512-m+6nTEOadJZuTPkKR/SYK3A2d7FZrgElol9UP1Kae90VVU4a6mxnPuLiIW1m4Cq4gZ/nWb9GrdVXJCoCazDAbg==",
       "dev": true
     },
+    "node_modules/@types/node-fetch": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.2.tgz",
+      "integrity": "sha512-DHqhlq5jeESLy19TYhLakJ07kNumXWjcDdxXsLUMJZ6ue8VZJj4kLPQVE/2mdHh3xZziNF1xppu5lwmS53HR+A==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "form-data": "^3.0.0"
+      }
+    },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
@@ -1195,6 +1206,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -1561,6 +1578,18 @@
       "integrity": "sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ==",
       "dev": true
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/commander": {
       "version": "9.4.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-9.4.0.tgz",
@@ -1694,6 +1723,15 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/diff": {
@@ -2296,6 +2334,20 @@
       },
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
+      "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
+      "dev": true,
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/formdata-polyfill": {
@@ -3259,6 +3311,27 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/mimic-fn": {
@@ -5672,6 +5745,16 @@
       "integrity": "sha512-m+6nTEOadJZuTPkKR/SYK3A2d7FZrgElol9UP1Kae90VVU4a6mxnPuLiIW1m4Cq4gZ/nWb9GrdVXJCoCazDAbg==",
       "dev": true
     },
+    "@types/node-fetch": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.2.tgz",
+      "integrity": "sha512-DHqhlq5jeESLy19TYhLakJ07kNumXWjcDdxXsLUMJZ6ue8VZJj4kLPQVE/2mdHh3xZziNF1xppu5lwmS53HR+A==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "form-data": "^3.0.0"
+      }
+    },
     "@types/normalize-package-data": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
@@ -5918,6 +6001,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
       "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
+      "dev": true
+    },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "dev": true
     },
     "balanced-match": {
@@ -6177,6 +6266,15 @@
       "integrity": "sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ==",
       "dev": true
     },
+    "combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
+    },
     "commander": {
       "version": "9.4.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-9.4.0.tgz",
@@ -6280,6 +6378,12 @@
           "dev": true
         }
       }
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true
     },
     "diff": {
       "version": "5.0.0",
@@ -6713,6 +6817,17 @@
       "requires": {
         "cross-spawn": "^7.0.0",
         "signal-exit": "^3.0.2"
+      }
+    },
+    "form-data": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
+      "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
+      "dev": true,
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
       }
     },
     "formdata-polyfill": {
@@ -7414,6 +7529,21 @@
       "requires": {
         "braces": "^3.0.2",
         "picomatch": "^2.3.1"
+      }
+    },
+    "mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true
+    },
+    "mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "requires": {
+        "mime-db": "1.52.0"
       }
     },
     "mimic-fn": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@inlivedev/inlive-js-sdk",
-  "version": "1.0.0",
+  "version": "0.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@inlivedev/inlive-js-sdk",
-      "version": "1.0.0",
+      "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
         "node-fetch": "3.2.10"
@@ -32,10 +32,11 @@
         "nock": "^13.2.9",
         "nyc": "^15.1.0",
         "prettier": "^2.7.1",
-        "rimraf": "^3.0.2",
-        "rollup": "^2.79.0",
         "sinon": "^14.0.0",
         "typescript": "^4.8.2"
+      },
+      "engines": {
+        "node": " >=14.16 || >=16.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -4390,21 +4391,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/rollup": {
-      "version": "2.79.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.0.tgz",
-      "integrity": "sha512-x4KsrCgwQ7ZJPcFA/SUu6QVcYlO7uRLfLAy0DSA4NS2eG8japdbpM50ToH7z4iObodRYOJ0soneF0iaQRJ6zhA==",
-      "dev": true,
-      "bin": {
-        "rollup": "dist/bin/rollup"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.2"
-      }
-    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -8246,15 +8232,6 @@
       "dev": true,
       "requires": {
         "glob": "^7.1.3"
-      }
-    },
-    "rollup": {
-      "version": "2.79.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.0.tgz",
-      "integrity": "sha512-x4KsrCgwQ7ZJPcFA/SUu6QVcYlO7uRLfLAy0DSA4NS2eG8japdbpM50ToH7z4iObodRYOJ0soneF0iaQRJ6zhA==",
-      "dev": true,
-      "requires": {
-        "fsevents": "~2.3.2"
       }
     },
     "run-parallel": {

--- a/package.json
+++ b/package.json
@@ -6,18 +6,11 @@
   "license": "MIT",
   "type": "module",
   "exports": {
-    ".": {
-      "import": "./packages/index.js"
-    },
-    "./app": {
-      "import": "./packages/app/index.js"
-    },
-    "./stream": {
-      "import": "./packages/stream/index.js"
-    },
-    "./event": {
-      "import": "./packages/event/index.js"
-    }
+    ".": "./packages/index.js",
+    "./app": "./packages/app/index.js",
+    "./stream": "./packages/stream/index.js",
+    "./event": "./packages/event/index.js",
+    "./packages/internal/*": null
   },
   "files": [
     "packages"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,9 @@
       "import": "./packages/event/index.js"
     }
   },
-  "files": ["packages"],
+  "files": [
+    "packages"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/inlivedev/inlive-js-sdk/"
@@ -38,6 +40,7 @@
     "@types/chai": "^4.3.3",
     "@types/mocha": "^9.1.1",
     "@types/node": "^18.7.18",
+    "@types/node-fetch": "^2.6.2",
     "@typescript-eslint/eslint-plugin": "^5.36.2",
     "@typescript-eslint/parser": "^5.36.2",
     "chai": "^4.3.6",

--- a/package.json
+++ b/package.json
@@ -1,22 +1,33 @@
 {
   "name": "@inlivedev/inlive-js-sdk",
-  "version": "1.0.0",
-  "description": "",
+  "version": "0.1.0",
+  "description": "InLive JavaScript SDK",
   "keywords": [],
   "license": "MIT",
-  "source": "./packages/index.js",
-  "main": "./dist/index.js",
-  "module": "./dist/index.mjs",
-  "types": "./dist/index.d.ts",
   "type": "module",
-  "files": [
-    "dist"
-  ],
+  "types": "./packages/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./packages/index.js"
+    },
+    "./app": {
+      "import": "./packages/app/index.js"
+    },
+    "./stream": {
+      "import": "./packages/stream/index.js"
+    },
+    "./event": {
+      "import": "./packages/event/index.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "files": ["packages"],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/inlivedev/inlive-js-sdk/"
+  },
   "scripts": {
-    "clean": "rimraf dist",
     "prepare": "husky install",
-    "prebuild": "npm run clean",
-    "build": "rollup -c",
     "lint": "eslint --cache",
     "lint:packages": "npm run lint \"packages/**/*.js\"",
     "prettier": "prettier --write",
@@ -46,12 +57,13 @@
     "nock": "^13.2.9",
     "nyc": "^15.1.0",
     "prettier": "^2.7.1",
-    "rimraf": "^3.0.2",
-    "rollup": "^2.79.0",
     "sinon": "^14.0.0",
     "typescript": "^4.8.2"
   },
   "dependencies": {
     "node-fetch": "3.2.10"
+  },
+  "engines": {
+    "node": " >=14.16 || >=16.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "keywords": [],
   "license": "MIT",
   "type": "module",
-  "types": "./packages/index.d.ts",
   "exports": {
     ".": {
       "import": "./packages/index.js"
@@ -18,8 +17,7 @@
     },
     "./event": {
       "import": "./packages/event/index.js"
-    },
-    "./package.json": "./package.json"
+    }
   },
   "files": ["packages"],
   "repository": {

--- a/packages/app/init/init.js
+++ b/packages/app/init/init.js
@@ -1,6 +1,6 @@
 /**
  * @typedef Config
- * @property {string | undefined} api_key - A string of key that will be used to access inLive protected API
+ * @property {string} api_key - A string of key that will be used to access inLive protected API
  */
 
 /**

--- a/packages/index.js
+++ b/packages/index.js
@@ -1,1 +1,3 @@
 export { InliveApp } from './app/index.js'
+export { InliveEvent } from './event/index.js'
+export { InliveStream } from './stream/index.js'

--- a/packages/stream/get-stream/get-stream.js
+++ b/packages/stream/get-stream/get-stream.js
@@ -3,7 +3,7 @@ import { Internal } from '../../internal/index.js'
 /**
  * @typedef FetchResponse
  * @property {object} status -- A status response
- * @property {object} data -- A return data as per endpoint
+ * @property {Object<any, any>} data -- A return data as per endpoint
  */
 
 /**

--- a/packages/stream/prepare-stream/prepare-stream.js
+++ b/packages/stream/prepare-stream/prepare-stream.js
@@ -6,7 +6,7 @@ import { event } from '../../event/event.js'
 /**
  * @typedef Config
  * @property {number} stream_id - The ID of the stream
- * @property {import('../../internal/webrtc/webrtc').MediaObject} media - The media object argument to set the media for the stream
+ * @property {import('../../internal/webrtc/webrtc.js').MediaObject} media - The media object argument to set the media for the stream
  */
 
 /**

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,8 @@
 {
   "compilerOptions": {
     "target": "es2018",
+    "module": "node16",
+    "moduleResolution": "node16",
     "allowJs": true,
     "checkJs": true,
     "noEmit": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "target": "es2018",
     "allowJs": true,
     "checkJs": true,
     "noEmit": true,


### PR DESCRIPTION
# Description
This is a pre-publish PR consisting of configuration setup and fixing some type checking errors before merging to `main` branch and publishing the SDK.
- For the initial publish, we want to go [pure ESM](https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c). This SDK will only ship ES modules and currently cannot be `require()`'d using the CommonJS module system. Why ES module? Because ES module is the current JavaScript module standard. This SDK will probably support the CommonJS module in the future. This will be an improvement for the SDK.
- Because we only ship ES modules, we can go build-less for now. Meaning no build process and we will ship the existing modules inside the `packages` directory as they are.
- Inlive JS SDK currently is not stable enough. Expect changes and bugs. Because of this the semantic initial version that we will take is start from the version 0.1.0.
- The SDK module entry points are exposed through the package.json [`exports` fields](https://nodejs.org/api/packages.html#exports). We removed the legacy `main`, and `module` entry points.
- Currently, we haven't published `types` declaration files and only use JSDoc annotation. Therefore, the `types` in package.json is removed for now.
- This PR also fixes some type check errors and warning from typescript.

Using [npm-link](https://docs.npmjs.com/cli/v8/commands/npm-link) we can install this SDK locally in other projects without publishing it first. The code below to import the SDK works in the node environment.
```js
import { InliveApp } from '@inlivedev/inlive-js-sdk/app'
import { InliveStream } from '@inlivedev/inlive-js-sdk/stream'
import { InliveEvent } from '@inlivedev/inlive-js-sdk/event'

console.log('inliveApp', InliveApp.init)
console.log('InliveStream', InliveStream.createStream)
console.log('InliveEvent', InliveEvent)
```

As the browser cannot read a file system and doesn't natively resolve the node_module path, one way to use import the SDK is by referencing the specific file inside the node_modules.
```js
import { InliveApp } from './node_modules/@inlivedev/inlive-js-sdk/packages/app/index.js'
```
This is of course not the ideal approach. We want to import the SDK easily just like in the node environment. That's why in order to import the SDK on the browser, we need something that can resolve the node_module path. This is why tools such as [web-dev-server](https://modern-web.dev/docs/dev-server/overview/) and [vite](https://vitejs.dev/) exist to help the development easier by resolving the path to the node_modules and providing a dev server. For production, the SDK should be built and bundled with together with other modules