### PR TITLE
fix: fix uncaught error on fetch-http module

### DIFF
--- a/packages/internal/fetch-http/fetch-http.js
+++ b/packages/internal/fetch-http/fetch-http.js
@@ -74,10 +74,20 @@ export const fetchHttp = async (config = baseConfig) => {
     }
   }
 
+  /** @type {Response} */
   const response = await fetchHttpRequest(url, options)
-  const json = await response.json()
+  const contentType = response.headers.get('content-type')
 
-  return response.ok && json.code >= 200 && json.code < 300
+  let json = {}
+
+  if (contentType && contentType.includes('application/json')) {
+    json = await response.json()
+  } else {
+    const text = await response.text()
+    json = { data: text }
+  }
+
+  return response.ok && response.status >= 200 && response.status < 300
     ? Promise.resolve(json)
     : Promise.reject(json)
 }


### PR DESCRIPTION
# Description
This will fix the these uncaught error on fetch-http module.
1. Fix uncaught error when the content-type is not `application/json` which means the data is probably a string/text.
2. Change checking http status code to use `response.ok` & `response.status` instead.