### PR TITLE
fix: fix doc wrong event module method

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ To listen when a live stream session has finished the preparation and the sessio
 ```js
 import { InliveEvent } from '@inlivedev/inlive-js-sdk/event';
 
-InliveEvent.on('stream:ready-to-initialize-event', () => {
+InliveEvent.subscribe('stream:ready-to-initialize-event', () => {
   // handle when the live stream has finished the preparation
 })
 ```
@@ -193,24 +193,24 @@ To listen any event triggered by the SDK, you can listen those events by using t
 ```js
 import { InliveEvent } from '@inlivedev/inlive-js-sdk/event';
 
-const readyToInitializeEvent = InliveEvent.on('stream:ready-to-initialize-event', () => {
+const readyToInitializeEvent = InliveEvent.subscribe('stream:ready-to-initialize-event', () => {
   // handle established connection after calling the connection.connect method
 });
 
-const readyToStartEvent = InliveEvent.on('stream:ready-to-start-event', () => {
+const readyToStartEvent = InliveEvent.subscribe('stream:ready-to-start-event', () => {
   // handle established connection after calling the connection.connect method
 });
 
-const iceConnectionStateChange = InliveEvent.on('stream:ice-connection-state-change-event', (data) => {
+const iceConnectionStateChange = InliveEvent.subscribe('stream:ice-connection-state-change-event', (data) => {
   // handle ice connection state change event
   // https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/iceConnectionState
 });
 
-InliveEvent.on('stream:start-event', () => {
+InliveEvent.subscribe('stream:start-event', () => {
   // handle live stream start event
 });
 
-InliveEvent.on('stream:end-event', () => {
+InliveEvent.subscribe('stream:end-event', () => {
   // handle live stream end event
 });
 

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ To listen when a live stream session has finished the preparation and the sessio
 import { InliveEvent } from '@inlivedev/inlive-js-sdk/event';
 
 InliveEvent.subscribe('stream:ready-to-initialize-event', () => {
-  // handle when the live stream has finished the preparation
+  // handle when the live stream has finished preparing a stream session
 })
 ```
 
@@ -194,7 +194,7 @@ To listen any event triggered by the SDK, you can listen those events by using t
 import { InliveEvent } from '@inlivedev/inlive-js-sdk/event';
 
 const readyToInitializeEvent = InliveEvent.subscribe('stream:ready-to-initialize-event', () => {
-  // handle established connection after calling the connection.connect method
+  // handle when the live stream has finished preparing a stream session
 });
 
 const readyToStartEvent = InliveEvent.subscribe('stream:ready-to-start-event', () => {


### PR DESCRIPTION
This PR will fix the wrong method on the readme.md documentation. The wrong method is
`InliveEvent.on` should be changed to `InliveEvent. subscribe `