### PR TITLE
allow to passing origin and api version to SDK

### DIFF
--- a/packages/app/init/init.js
+++ b/packages/app/init/init.js
@@ -1,6 +1,8 @@
 /**
  * @typedef Config
  * @property {string} apiKey - A string of key that will be used to access inLive protected API
+ * @property {string} apiOrigin - A string of the API origin, by default it will pointed to https://api.inlive.app
+ * @property {string} apiVersion - A string of API version, by default it will be use v1
  */
 
 /**

--- a/packages/stream/create-stream/create-stream.js
+++ b/packages/stream/create-stream/create-stream.js
@@ -77,9 +77,21 @@ export const createStream = async (initObject, config) => {
       'Failed to create a new stream because the description of the stream is not in string format. A description must be in string format'
     )
   } else {
+    const {
+      config: { apiKey, apiOrigin, apiVersion },
+    } = initObject
+
+    const baseUrl = `${
+      typeof apiOrigin != 'undefined' ? apiOrigin : Internal.config.api.baseUrl
+    }/${
+      typeof apiVersion != 'undefined'
+        ? apiVersion
+        : Internal.config.api.version
+    }`
+
     let fetchResponse = await Internal.fetchHttp({
-      url: `${Internal.config.api.baseUrl}/${Internal.config.api.version}/streams/create`,
-      token: initObject.config.apiKey,
+      url: `${baseUrl}/streams/create`,
+      token: apiKey,
       method: 'POST',
       body: {
         name: config.name,

--- a/packages/stream/end-stream/end-stream.js
+++ b/packages/stream/end-stream/end-stream.js
@@ -41,10 +41,8 @@ const endStream = async (initInstance, config) => {
    */
 
   const {
-    config: { apiKey },
+    config: { apiKey, apiOrigin, apiVersion },
   } = initInstance
-
-  const { fetchHttp, config: baseConfig } = Internal
 
   const { streamId } = config
 
@@ -54,16 +52,21 @@ const endStream = async (initInstance, config) => {
    * ======================================================
    */
 
-  const baseUrl = `${baseConfig.api.baseUrl}/${baseConfig.api.version}`
+  const baseUrl = `${
+    typeof apiOrigin != 'undefined' ? apiOrigin : Internal.config.api.baseUrl
+  }/${
+    typeof apiVersion != 'undefined' ? apiVersion : Internal.config.api.version
+  }`
+
   try {
-    const response = await fetchHttp({
+    const response = await Internal.fetchHttp({
       url: `${baseUrl}/streams/${streamId}/end`,
       token: apiKey,
       method: 'POST',
       body: {},
     })
 
-    const latestStreamData = await getStream(streamId)
+    const latestStreamData = await getStream(initInstance, streamId)
 
     const successResponse = {
       status: {

--- a/packages/stream/get-stream/get-stream.js
+++ b/packages/stream/get-stream/get-stream.js
@@ -1,3 +1,4 @@
+import { InitializationInstance } from '../../app/init/init.js'
 import { Internal } from '../../internal/index.js'
 import camelcaseKeys from 'camelcase-keys'
 
@@ -10,11 +11,18 @@ import camelcaseKeys from 'camelcase-keys'
 /**
  * A get specific stream data module based on the stream ID passing parameter
  *
+ * @param {InitializationInstance} initObject -- initialization object
  * @param {number} streamId -- stream ID
  * @returns {Promise<FetchResponse>} returns the restructured data which content status & specific stream data
  * @throws {Error}
  */
-export const getStream = async (streamId) => {
+export const getStream = async (initObject, streamId) => {
+  if (!(initObject instanceof InitializationInstance)) {
+    throw new TypeError(
+      'Failed to process because initialization is not valid. Please provide required initialization argument which is the initialization instance returned by the init() function'
+    )
+  }
+
   if (streamId === null || streamId === undefined) {
     throw new Error(
       'Failed to get the stream data because the stream ID is empty. Please provide a stream ID'
@@ -24,8 +32,21 @@ export const getStream = async (streamId) => {
       'Failed to get the stream data because the stream ID is not in number format. A stream ID must be number format'
     )
   } else {
+    const {
+      config: { apiKey, apiOrigin, apiVersion },
+    } = initObject
+
+    const baseUrl = `${
+      typeof apiOrigin != 'undefined' ? apiOrigin : Internal.config.api.baseUrl
+    }/${
+      typeof apiVersion != 'undefined'
+        ? apiVersion
+        : Internal.config.api.version
+    }`
+
     let fetchResponse = await Internal.fetchHttp({
-      url: `${Internal.config.api.baseUrl}/${Internal.config.api.version}/streams/${streamId}`,
+      url: `${baseUrl}/streams/${streamId}`,
+      token: apiKey,
       method: 'GET',
     }).catch((error) => {
       return error

--- a/packages/stream/get-stream/get-stream.test.js
+++ b/packages/stream/get-stream/get-stream.test.js
@@ -2,6 +2,7 @@ import nock from 'nock'
 import { expect } from 'chai'
 import { getStream } from './get-stream.js'
 import { Internal } from '../../internal/index.js'
+import { init } from '../../app/init/init.js'
 
 describe('Get Stream Module', function () {
   describe('Basic test', function () {
@@ -11,9 +12,25 @@ describe('Get Stream Module', function () {
   })
 
   describe('Negative test', function () {
-    it('should return error response if function is called with no stream ID argument', async function () {
+    it('should return type error response if function is called with no init object', async function () {
       try {
         await getStream()
+      } catch (error) {
+        expect(error).to.be.an('error')
+        expect(error.name).to.be.equal('TypeError')
+        expect(error.message).to.be.equal(
+          'Failed to process because initialization is not valid. Please provide required initialization argument which is the initialization instance returned by the init() function'
+        )
+      }
+    })
+
+    it('should return error response if function is called with no stream ID argument', async function () {
+      try {
+        await getStream(
+          init({
+            apiKey: 'eyJhbGciOiJ.eyJleHAi.B01hriveOMR',
+          })
+        )
       } catch (error) {
         expect(error).to.be.an('error')
         expect(error.name).to.be.equal('Error')
@@ -25,7 +42,12 @@ describe('Get Stream Module', function () {
 
     it('should return error response if function is called with stream ID with not a number type', async function () {
       try {
-        await getStream('1')
+        await getStream(
+          init({
+            apiKey: 'eyJhbGciOiJ.eyJleHAi.B01hriveOMR',
+          }),
+          '1'
+        )
       } catch (error) {
         expect(error).to.be.an('error')
         expect(error.name).to.be.equal('TypeError')
@@ -35,7 +57,12 @@ describe('Get Stream Module', function () {
       }
 
       try {
-        await getStream({})
+        await getStream(
+          init({
+            apiKey: 'eyJhbGciOiJ.eyJleHAi.B01hriveOMR',
+          }),
+          {}
+        )
       } catch (error) {
         expect(error).to.be.an('error')
         expect(error.name).to.be.equal('TypeError')
@@ -45,7 +72,12 @@ describe('Get Stream Module', function () {
       }
 
       try {
-        await getStream([])
+        await getStream(
+          init({
+            apiKey: 'eyJhbGciOiJ.eyJleHAi.B01hriveOMR',
+          }),
+          []
+        )
       } catch (error) {
         expect(error).to.be.an('error')
         expect(error.name).to.be.equal('TypeError')
@@ -62,7 +94,12 @@ describe('Get Stream Module', function () {
         .reply(404, { code: 404, message: 'ID not found', data: '' })
 
       try {
-        await getStream(streamId)
+        await getStream(
+          init({
+            apiKey: 'eyJhbGciOiJ.eyJleHAi.B01hriveOMR',
+          }),
+          streamId
+        )
       } catch (error) {
         expect(error).to.be.an('error')
         expect(error.name).to.be.equal('Error')
@@ -113,12 +150,22 @@ describe('Get Stream Module', function () {
     })
 
     it('should call the getStream function', async function () {
-      const result = await getStream(streamId)
+      const result = await getStream(
+        init({
+          apiKey: 'eyJhbGciOiJ.eyJleHAi.B01hriveOMR',
+        }),
+        streamId
+      )
       expect(result.status.code).to.equal(200)
     })
 
     it('should return success response', async function () {
-      const result = await getStream(streamId)
+      const result = await getStream(
+        init({
+          apiKey: 'eyJhbGciOiJ.eyJleHAi.B01hriveOMR',
+        }),
+        streamId
+      )
 
       expect(result).to.be.an('object')
       expect(result).to.have.property('status').to.be.an('object')

--- a/packages/stream/get-streams/get-streams.js
+++ b/packages/stream/get-streams/get-streams.js
@@ -22,9 +22,21 @@ export const getStreams = async (initObject) => {
       'Failed to process because initialization is not valid. Please provide required initialization argument which is the initialization instance returned by the init() function'
     )
   } else {
+    const {
+      config: { apiKey, apiOrigin, apiVersion },
+    } = initObject
+
+    const baseUrl = `${
+      typeof apiOrigin != 'undefined' ? apiOrigin : Internal.config.api.baseUrl
+    }/${
+      typeof apiVersion != 'undefined'
+        ? apiVersion
+        : Internal.config.api.version
+    }`
+
     let fetchResponse = await Internal.fetchHttp({
-      url: `${Internal.config.api.baseUrl}/${Internal.config.api.version}/streams/`,
-      token: initObject.config.apiKey,
+      url: `${baseUrl}/streams/`,
+      token: apiKey,
       method: 'GET',
     }).catch((error) => {
       return error

--- a/packages/stream/init-stream/init-stream.js
+++ b/packages/stream/init-stream/init-stream.js
@@ -50,10 +50,8 @@ const initStream = async (initInstance, config) => {
    */
 
   const {
-    config: { apiKey },
+    config: { apiKey, apiOrigin, apiVersion },
   } = initInstance
-
-  const { fetchHttp, config: baseConfig } = Internal
 
   const { streamId, sessionDescription } = config
 
@@ -63,14 +61,18 @@ const initStream = async (initInstance, config) => {
    * ======================================================
    */
 
-  const baseUrl = `${baseConfig.api.baseUrl}/${baseConfig.api.version}`
+  const baseUrl = `${
+    typeof apiOrigin != 'undefined' ? apiOrigin : Internal.config.api.baseUrl
+  }/${
+    typeof apiVersion != 'undefined' ? apiVersion : Internal.config.api.version
+  }`
 
   try {
     const body = snakecaseKeys({
       sessionDescription,
     })
 
-    const response = await fetchHttp({
+    const response = await Internal.fetchHttp({
       url: `${baseUrl}/streams/${streamId}/init`,
       token: apiKey,
       method: 'POST',

--- a/packages/stream/prepare-stream/prepare-stream.js
+++ b/packages/stream/prepare-stream/prepare-stream.js
@@ -40,10 +40,8 @@ const prepareStream = async (initInstance, config) => {
    */
 
   const {
-    config: { apiKey },
+    config: { apiKey, apiOrigin, apiVersion },
   } = initInstance
-
-  const { fetchHttp, config: baseConfig } = Internal
 
   const { streamId } = config
 
@@ -53,10 +51,14 @@ const prepareStream = async (initInstance, config) => {
    * ======================================================
    */
 
-  const baseUrl = `${baseConfig.api.baseUrl}/${baseConfig.api.version}`
+  const baseUrl = `${
+    typeof apiOrigin != 'undefined' ? apiOrigin : Internal.config.api.baseUrl
+  }/${
+    typeof apiVersion != 'undefined' ? apiVersion : Internal.config.api.version
+  }`
 
   try {
-    const response = await fetchHttp({
+    const response = await Internal.fetchHttp({
       url: `${baseUrl}/streams/${streamId}/prepare`,
       token: apiKey,
       method: 'POST',

--- a/packages/stream/start-stream/start-stream.js
+++ b/packages/stream/start-stream/start-stream.js
@@ -41,10 +41,8 @@ const startStream = async (initInstance, config) => {
    */
 
   const {
-    config: { apiKey },
+    config: { apiKey, apiOrigin, apiVersion },
   } = initInstance
-
-  const { fetchHttp, config: baseConfig } = Internal
 
   const { streamId } = config
 
@@ -54,16 +52,20 @@ const startStream = async (initInstance, config) => {
    * ======================================================
    */
 
-  const baseUrl = `${baseConfig.api.baseUrl}/${baseConfig.api.version}`
+  const baseUrl = `${
+    typeof apiOrigin != 'undefined' ? apiOrigin : Internal.config.api.baseUrl
+  }/${
+    typeof apiVersion != 'undefined' ? apiVersion : Internal.config.api.version
+  }`
   try {
-    const response = await fetchHttp({
+    const response = await Internal.fetchHttp({
       url: `${baseUrl}/streams/${streamId}/start`,
       token: apiKey,
       method: 'POST',
       body: {},
     })
 
-    const latestStreamData = await getStream(streamId)
+    const latestStreamData = await getStream(initInstance, streamId)
 
     const successResponse = {
       status: {


### PR DESCRIPTION
This PR will allow us to pass the API origin URL and API version to SDK to resolve issue #39 . The API origin and API version will affect all API request base URLs and allow us to test SDK with the local or development version of API.