### PR TITLE
feat: enable support for retrieving a list of streams data through pagination

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,10 +162,13 @@ await stream.end()
 
 #### Get a list of streams
 
-You can get to see the list of the streams that you've created by using the `getStreams` module.
+You can get to see the list of the streams that you have created by using the `getStreams` module. The result wil be paginated and return the latest 10 streams data already created by you. You can change the pagination options by setting the `page` and `pageSize` fields.
 
 ```js
-const streamList = await InliveStream.getStreams(inliveApp)
+const streamList = await InliveStream.getStreams(inliveApp, {
+  page: 1, // set which page number will be displayed (optional)
+  pageSize: 10 // set the total number of streams displayed on one page (optional)
+})
 ```
 
 ### Events

--- a/packages/stream/create-stream/create-stream.js
+++ b/packages/stream/create-stream/create-stream.js
@@ -105,8 +105,10 @@ export const createStream = async (initObject, parameters) => {
       hlsUrl: stream.hls_url,
       dashUrl: stream.dash_url,
       createdAt: stream.created_at,
+      preparedAt: stream.prepared_at,
       startedAt: stream.start_time,
       endedAt: stream.end_time,
+      quality: stream.quality,
     }
     return new Stream(initObject, streamResponse)
   }

--- a/packages/stream/fetch-stream/fetch-stream.js
+++ b/packages/stream/fetch-stream/fetch-stream.js
@@ -9,8 +9,10 @@ import { Internal } from '../../internal/index.js'
  * @property {string} hlsUrl - HLS manifest URL
  * @property {string} dashUrl - a Dash format URL
  * @property {string} createdAt - a time string when the stream is created
+ * @property {string} preparedAt - a time string when the stream is prepared
  * @property {string} startedAt - a time string when the stream is started
  * @property {string} endedAt - a time string when the stream is ended
+ * @property {string} quality - the quality of the stream
  */
 
 /**
@@ -58,8 +60,10 @@ export const fetchStream = async (baseUrl, streamId) => {
       hlsUrl: stream.hls_url,
       dashUrl: stream.dash_url,
       createdAt: stream.created_at,
+      preparedAt: stream.prepared_at,
       startedAt: stream.start_time,
       endedAt: stream.end_time,
+      quality: stream.quality,
     }
 
     return streamResponse

--- a/packages/stream/get-streams/get-streams.js
+++ b/packages/stream/get-streams/get-streams.js
@@ -1,60 +1,126 @@
 import { InitializationInstance } from '../../app/init/init.js'
 import { Internal } from '../../internal/index.js'
-import camelcaseKeys from 'camelcase-keys'
+import merge from 'lodash-es/merge'
 
 /**
- * @typedef FetchResponse
- * @property {object} status -- A status response
- * @property {Array<any>} data -- A return data as per endpoint
+ * @typedef StreamData
+ * @property {number} id - id of stream
+ * @property {string} name - name of stream
+ * @property {string} slug - slug or URL friendly name
+ * @property {string} description - description for the stream
+ * @property {string} hlsUrl - HLS manifest URL
+ * @property {string} dashUrl - a Dash format URL
+ * @property {string} createdAt - a time string when the stream is created
+ * @property {string} preparedAt - a time string when the stream is prepared
+ * @property {string} startedAt - a time string when the stream is started
+ * @property {string} endedAt - a time string when the stream is ended
+ * @property {string} quality - the quality of the stream
  */
+
+/**
+ * @typedef MetaData
+ * @property {number} page - current page
+ * @property {number} limit - page size limit in one page
+ * @property {number} totalRecords - total number of stream records
+ * @property {number} totalPages - total number of pages
+ */
+
+/**
+ * @typedef StreamListResponse
+ * @property {number} code -- A status code
+ * @property {string} message -- A status message
+ * @property {Array<StreamData>} data -- list of streams data in array
+ * @property {MetaData} meta - A meta data
+ */
+
+/**
+ * @typedef PaginationParameters
+ * @property {number} [page] - the number of displayed page (default: 1)
+ * @property {number} [pageSize] - the total number of streams displayed on one page (default: 10)
+ */
+
+const defaultParameters = {
+  page: 1,
+  pageSize: 10,
+}
 
 /**
  * A get list of streams module based on the API Key (per project)
  *
  * @function
  * @param {InitializationInstance} initInstance -- initialization object
- * @returns {Promise<FetchResponse>} returns the restructured data which content status & list of streams data
+ * @param {PaginationParameters} [parameters] - config parameters in key/value pair
+ * @returns {Promise<StreamListResponse>} returns the restructured data which content status & list of streams data
  * @throws {Error}
  */
-export const getStreams = async (initInstance) => {
+export const getStreams = async (initInstance, parameters) => {
+  merge(defaultParameters, parameters)
+
   if (initInstance.constructor.name !== InitializationInstance.name) {
     throw new TypeError(
       'Failed to process because initialization is not valid. Please provide required initialization argument which is the initialization instance returned by the init() function'
     )
-  } else {
-    const baseUrl = `${initInstance.config.api.baseUrl}/${initInstance.config.api.version}`
-
-    let fetchResponse = await Internal.fetchHttp({
-      url: `${baseUrl}/streams`,
-      token: initInstance.config.apiKey,
-      method: 'GET',
-    }).catch((error) => {
-      return error
-    })
-
-    if (fetchResponse) {
-      switch (fetchResponse.code) {
-        case 200:
-          fetchResponse = {
-            status: {
-              code: fetchResponse.code,
-              message: 'Successfully got a list of streams',
-              type: 'success',
-            },
-            data: camelcaseKeys(fetchResponse.data),
-          }
-
-          break
-        case 403: {
-          throw new Error(
-            'Failed to get a list of streams because the API Key is not valid. Please provide a valid and active API Key.'
-          )
-        }
-        default:
-          break
-      }
-    }
-
-    return fetchResponse
   }
+
+  if (
+    typeof defaultParameters.page !== 'undefined' &&
+    typeof defaultParameters.page !== 'number'
+  ) {
+    throw new TypeError('Invalid `page` parameter')
+  }
+
+  if (
+    typeof defaultParameters.pageSize !== 'undefined' &&
+    typeof defaultParameters.pageSize !== 'number'
+  ) {
+    throw new TypeError('Invalid `pageSize` parameter')
+  }
+
+  const baseUrl = `${initInstance.config.api.baseUrl}/${initInstance.config.api.version}`
+
+  let fetchResponse = await Internal.fetchHttp({
+    url: `${baseUrl}/streams?page=${defaultParameters.page}&page_size=${defaultParameters.pageSize}`,
+    token: initInstance.config.apiKey,
+    method: 'GET',
+  }).catch((error) => {
+    return error
+  })
+
+  if (fetchResponse.code === 403) {
+    throw new Error(
+      'Failed to get a list of streams because the API Key is not valid. Please provide a valid and active API Key.'
+    )
+  }
+
+  const result = {
+    code: fetchResponse.code || 500,
+    message: fetchResponse.message || 'Error',
+    data: Array.isArray(fetchResponse.data)
+      ? fetchResponse.data.map(
+          /* eslint-disable @typescript-eslint/ban-ts-comment */
+          /*@ts-ignore */
+          (stream) => ({
+            id: stream.id,
+            name: stream.name,
+            slug: stream.slug,
+            description: stream.description,
+            hlsUrl: stream.hls_url,
+            dashUrl: stream.dash_url,
+            createdAt: stream.created_at,
+            preparedAt: stream.prepared_at,
+            startedAt: stream.start_time,
+            endedAt: stream.end_time,
+            quality: stream.quality,
+          })
+        )
+      : [],
+    meta: {
+      page: fetchResponse.meta.page,
+      limit: fetchResponse.meta.limit,
+      totalRecords: fetchResponse.meta.total_records,
+      totalPages: fetchResponse.meta.total_pages,
+    },
+  }
+
+  return result
 }

--- a/packages/stream/get-streams/get-streams.js
+++ b/packages/stream/get-streams/get-streams.js
@@ -35,7 +35,7 @@ import merge from 'lodash-es/merge'
 
 /**
  * @typedef PaginationParameters
- * @property {number} [page] - the number of displayed page (default: 1)
+ * @property {number} [page] - the page number will be displayed (default: 1)
  * @property {number} [pageSize] - the total number of streams displayed on one page (default: 10)
  */
 


### PR DESCRIPTION
# Description
This PR will update the `getStreams` module and readme. This will enable the pagination support on SDK. The pagination options can be set by passing `page` and `pageSize` values on object parameter.