### PR TITLE
fix: remove remote stream from list when the stream tracks receive an `ended` event

### DIFF
--- a/packages/room/peer/peer.js
+++ b/packages/room/peer/peer.js
@@ -588,6 +588,12 @@ export const createPeer = ({ api, createStream, event, streams, config }) => {
         }
       })
 
+      for (const track of mediaStream.getTracks()) {
+        track.addEventListener('ended', () => {
+          this.removeStream(mediaStream.id)
+        })
+      }
+
       const draftStream = this._streams.getDraft(mediaStream.id) || {}
 
       this.addStream(mediaStream.id, {


### PR DESCRIPTION
## Description

This PR will fix the issue about remote stream (participant) is not removed from the stream list when the stream tracks receive an `ended` event.