### PR TITLE
add voice activity on stream

### DIFF
--- a/packages/room/README.md
+++ b/packages/room/README.md
@@ -230,16 +230,34 @@ peer.disconnect();
 
   A method to replace the track currently being sent by sender with a new MediaStreamTrack.
 
+
+#### Events
+
+- `peer.addEventListener('voiceactivity', callback:function(ev:CustomEvent))`
+  
+  A custom event to listen for voice activity level changes. The callback function will receive a CustomEvent object with `detail` property that contains the the `voiceActivity` object. The `voiceActivity` object type is described below.
+  ```
+  type VoiceActivity = {
+    type: string
+    track_id: string
+    stream_id: string
+    ssrc: number
+    clock_rate: number
+    audio_levels?: AudioLevel[]
+  }
+  ```
+
 ### Stream object
 
 The stream object is an object created and stored after the method `peer.addStream()` is called. This object is mainly used to store the data for a specific MediaStream added by `peer.addStream()` method. We can say a single stream object is the representative of a single participant or we can call it a **client**.
 
 #### Properties
 
-The stream object holds read-only properties based on the data client provided when creating a new stream.
+The stream object holds read-only properties based on the provided client's data when creating a new stream.
 - **id**: The ID or key identifier of the stream
-- **clientId**: The ID of the client which transceive this specific stream.
-- **name**: The name or label for identification purpose.
+- **clientId**: The ID of the client that transceives this specific stream.
+- **name**: The name or label for identification purposes.
+- **audioLevel**: The audio level of the stream. The value is 0 to 127 refer to [this doc](https://datatracker.ietf.org/doc/rfc6464/). The audio level will only updated if the stream has audio track and it is a remote stream. 
 - **origin**: The origin of the stream. The value is between a `local` or `remote`
 - **source**: The source of the stream. MediaStream from `getUserMedia()` should set a **media** source and the one from `getDisplayMedia()` should set a **screen** source.
 - **mediaStream**: The MediaStream object
@@ -249,3 +267,10 @@ The stream object holds read-only properties based on the data client provided w
 - `stream.replaceTrack(track: MediaStreamTrack)`
 
   A method to replace the track currently being used by MediaStream with a new MediaStreamTrack
+
+
+#### Events
+
+- `stream.addEventListener('voiceactivity', callback:function(ev:CustomEvent))`
+  
+  A custom event to listen for voice activity level changes. The callback function will receive a CustomEvent object with `detail` property that contains the the `audioLevel` value.

--- a/packages/room/README.md
+++ b/packages/room/README.md
@@ -234,16 +234,22 @@ peer.disconnect();
 #### Events
 
 - `peer.addEventListener('voiceactivity', callback:function(ev:CustomEvent))`
-  
+
   A custom event to listen for voice activity level changes. The callback function will receive a CustomEvent object with `detail` property that contains the the `voiceActivity` object. The `voiceActivity` object type is described below.
-  ```
+  ```ts
+  type AudioLevel = {
+    sequenceNo: number
+    timestamp: number
+    audioLevel: number
+  }
+
   type VoiceActivity = {
     type: string
-    track_id: string
-    stream_id: string
+    trackID: string
+    streamID: string
     ssrc: number
-    clock_rate: number
-    audio_levels?: AudioLevel[]
+    clockRate: number
+    audioLevels?: AudioLevel[]
   }
   ```
 
@@ -257,7 +263,7 @@ The stream object holds read-only properties based on the provided client's data
 - **id**: The ID or key identifier of the stream
 - **clientId**: The ID of the client that transceives this specific stream.
 - **name**: The name or label for identification purposes.
-- **audioLevel**: The audio level of the stream. The value is 0 to 127 refer to [this doc](https://datatracker.ietf.org/doc/rfc6464/). The audio level will only updated if the stream has audio track and it is a remote stream. 
+- **audioLevel**: The audio level of the stream. The value is 0 to 127 refer to [this doc](https://datatracker.ietf.org/doc/rfc6464/). The audio level will only updated if the stream has audio track and it is a remote stream.
 - **origin**: The origin of the stream. The value is between a `local` or `remote`
 - **source**: The source of the stream. MediaStream from `getUserMedia()` should set a **media** source and the one from `getDisplayMedia()` should set a **screen** source.
 - **mediaStream**: The MediaStream object
@@ -272,5 +278,5 @@ The stream object holds read-only properties based on the provided client's data
 #### Events
 
 - `stream.addEventListener('voiceactivity', callback:function(ev:CustomEvent))`
-  
+
   A custom event to listen for voice activity level changes. The callback function will receive a CustomEvent object with `detail` property that contains the the `audioLevel` value.

--- a/packages/room/peer/peer-types.d.ts
+++ b/packages/room/peer/peer-types.d.ts
@@ -56,18 +56,18 @@ export declare namespace RoomPeerType {
   }
 
   type AudioLevel = {
-    sequence_no: number
+    sequenceNo: number
     timestamp: number
-    audio_level: number
+    audioLevel: number
   }
 
   type VoiceActivity = {
     type: string
-    track_id: string
-    stream_id: string
+    trackID: string
+    streamID: string
     ssrc: number
-    clock_rate: number
-    audio_levels?: AudioLevel[]
+    clockRate: number
+    audioLevels?: AudioLevel[]
   }
 
   type VoiceActivityCallback = (voiceActivity: VoiceActivity) => void

--- a/packages/room/peer/peer-types.d.ts
+++ b/packages/room/peer/peer-types.d.ts
@@ -54,4 +54,21 @@ export declare namespace RoomPeerType {
   type RTCRtpSVCTransceiverInit = RTCRtpTransceiverInit & {
     sendEncodings?: RTCRtpSVCEncodingParameters[]
   }
+
+  type AudioLevel = {
+    sequence_no: number
+    timestamp: number
+    audio_level: number
+  }
+
+  type VoiceActivity = {
+    type: string
+    track_id: string
+    stream_id: string
+    ssrc: number
+    clock_rate: number
+    audio_levels?: AudioLevel[]
+  }
+
+  type VoiceActivityCallback = (voiceActivity: VoiceActivity) => void
 }

--- a/packages/room/peer/peer.js
+++ b/packages/room/peer/peer.js
@@ -617,6 +617,14 @@ export const createPeer = ({ api, createStream, event, streams, config }) => {
         for (const videoElement of this._pendingObservedVideo) {
           this._videoObserver.observe(videoElement)
         }
+
+        internalChannel.addEventListener('message', (event) => {
+          const data = JSON.parse(event.data)
+
+          if (data.type === 'vad_started' || data.type === 'vad_ended') {
+            this._onVoiceActivity(data)
+          }
+        })
       }
     }
 
@@ -645,6 +653,17 @@ export const createPeer = ({ api, createStream, event, streams, config }) => {
       }
 
       this._event.emit(PeerEvents.STREAM_AVAILABLE, { stream })
+    }
+
+    /**
+     * @param {import('./peer-types.d.ts').RoomPeerType.VoiceActivity} vad
+     */
+    _onVoiceActivity = (vad) => {
+      const stream = this._streams.getStream(vad.stream_id)
+
+      if (!stream) return
+
+      stream.addVoiceActivity(vad)
     }
   }
 

--- a/packages/room/peer/peer.js
+++ b/packages/room/peer/peer.js
@@ -24,7 +24,7 @@ const MIN_BITRATE = 150 * 1000
 
 /** @param {import('./peer-types.js').RoomPeerType.PeerDependencies} peerDependencies Dependencies for peer module */
 export const createPeer = ({ api, createStream, event, streams, config }) => {
-  const Peer = class {
+  const Peer = class extends EventTarget {
     _roomId = ''
     _clientId = ''
     _api
@@ -40,6 +40,7 @@ export const createPeer = ({ api, createStream, event, streams, config }) => {
     _pendingObservedVideo
 
     constructor() {
+      super()
       this._api = api
       this._event = event
       this._streams = streams
@@ -659,6 +660,14 @@ export const createPeer = ({ api, createStream, event, streams, config }) => {
      * @param {import('./peer-types.d.ts').RoomPeerType.VoiceActivity} vad
      */
     _onVoiceActivity = (vad) => {
+      const event = new CustomEvent('voiceactivity', {
+        detail: {
+          voiceActivity: vad,
+        },
+      })
+
+      this.dispatchEvent(event)
+
       const stream = this._streams.getStream(vad.stream_id)
 
       if (!stream) return

--- a/packages/room/stream/stream.js
+++ b/packages/room/stream/stream.js
@@ -6,6 +6,9 @@ export const createStream = () => {
     origin
     source
     mediaStream
+    /** @type {Array<import('../peer/peer-types').RoomPeerType.VoiceActivityCallback>} */
+    voiceActivityCallbacks
+    audioLevel
 
     /**
      * @param {import('./stream-types.js').RoomStreamType.StreamParameters} streamParameters
@@ -17,6 +20,8 @@ export const createStream = () => {
       this.origin = origin
       this.source = source
       this.mediaStream = mediaStream
+      this.voiceActivityCallbacks = []
+      this.audioLevel = 0
     }
 
     /**
@@ -36,6 +41,33 @@ export const createStream = () => {
         this.mediaStream.addTrack(newTrack)
       }
     }
+
+    /**
+     * Listen for voice activity from stream
+     * @param {import('../peer/peer-types.d.ts').RoomPeerType.VoiceActivityCallback} callback
+     * @returns {void}
+     */
+    onVoiceActivity = (callback) => {
+      this.voiceActivityCallbacks.push(callback)
+    }
+
+    /**
+     * @param {import('../peer/peer-types.d.ts').RoomPeerType.VoiceActivity} activity
+     * @returns {void}
+     */
+    addVoiceActivity = (activity) => {
+      for (const callback of this.voiceActivityCallbacks) {
+        callback(activity)
+      }
+
+      if (activity.audio_levels) {
+        for (const level of activity.audio_levels) {
+          this.audioLevel = level.audio_level
+        }
+      } else {
+        this.audioLevel = 0
+      }
+    }
   }
 
   return {
@@ -52,7 +84,10 @@ export const createStream = () => {
         origin: stream.origin,
         source: stream.source,
         mediaStream: stream.mediaStream,
+        audioLevel: 0,
         replaceTrack: stream.replaceTrack,
+        onVoiceActivity: stream.onVoiceActivity,
+        addVoiceActivity: stream.addVoiceActivity,
       })
     },
   }


### PR DESCRIPTION
add new API on stream and peer package so it can be used to animate something on voice detection based on audio volume level. The new API will use like this:

```javascript
peer.addEventListener('voiceactivity',(ev)=>{
  // type AudioLevel = {
  //   sequence_no: number
  //   timestamp: number
  //   audio_level: number
  // }

  // type VoiceActivity = {
  //   type: string
  //   track_id: string
  //   stream_id: string
  //   ssrc: number
  //   clock_rate: number
  //   audio_levels?: AudioLevel[]
  // }
  console.log(ev.detail.voiceActivity)
})

```
Use peer voice activity event to do manual query on video element and add animation to show the video is the one that currently speaking

or 

```javascript
stream.addEventListener('voiceactivity',(ev)=>{
  console.log(ev.detail.audioLevel)
})
``` 

Use stream voice activity audio level as an element attribute to use it  directly for UI rendering 