### PR TITLE
reduce bitrate to optimize bandwidth

### DIFF
--- a/packages/room/peer/peer.js
+++ b/packages/room/peer/peer.js
@@ -18,9 +18,11 @@ export const PeerEvents = {
   _INTERNAL_DATACHANNEL_AVAILABLE: 'internalDataChannelAvailable',
 }
 
-const MAX_BITRATE = 1500 * 1000
-const MID_BITRATE = 500 * 1000
-const MIN_BITRATE = 150 * 1000
+// This bitrate based on https://livekit.io/webrtc/bitrate-guide
+// optimal for 720p on webcam streaming
+const MAX_BITRATE = 700 * 1000
+const MID_BITRATE = 300 * 1000
+const MIN_BITRATE = 100 * 1000
 
 /** @param {import('./peer-types.js').RoomPeerType.PeerDependencies} peerDependencies Dependencies for peer module */
 export const createPeer = ({ api, createStream, event, streams, config }) => {


### PR DESCRIPTION
Because we switched the codec to VP9 as the default codec. The bitrate can be reduced to 700kbps for webcam streaming based on [this reference](https://livekit.io/webrtc/bitrate-guide). Once this PR merged then we need to rebuild inlive-room to test it.