### PR TITLE
fix: separate room event module

### DIFF
--- a/packages/index.js
+++ b/packages/index.js
@@ -1,3 +1,3 @@
 export { InliveApp } from './app/index.js'
 export { InliveStream, Stream, Stat } from './stream/index.js'
-export { Room } from './room/index.js'
+export { Room, RoomEvent } from './room/index.js'

--- a/packages/room/README.md
+++ b/packages/room/README.md
@@ -7,9 +7,9 @@ This package is used to work with [inLive Hub and Room API services](https://hub
 To use this package, you need to import a `Room` module and initialize it in a global scope where you can export and import the room object returned everywhere in your application.
 
 ```js
-import { Room } from '@inlivedev/inlive-js-sdk';
+import { Room, RoomEvent } from '@inlivedev/inlive-js-sdk';
 // Or if you prefer to load only the room module
-import { Room } from '@inlivedev/inlive-js-sdk/dist/room.js';
+import { Room, RoomEvent } from '@inlivedev/inlive-js-sdk/dist/room.js';
 
 const room = Room()
 ```
@@ -37,11 +37,11 @@ const peer = await room.createPeer(roomData.data.roomId, client.data.clientId);
 await room.createDataChannel(roomData.data.roomId, 'my-channel')
 
 // listen for a specific room event
-room.on(room.event.STREAM_AVAILABLE, function () {
+room.on(RoomEvent.STREAM_AVAILABLE, function () {
   // handle event
 });
 
-room.on(room.event.STREAM_REMOVED, function () {
+room.on(RoomEvent.STREAM_REMOVED, function () {
   // handle event
 });
 
@@ -51,12 +51,6 @@ await room.leaveRoom(roomData.data.roomId, client.data.clientId);
 // To end the room for everyone
 await room.endRoom(roomData.data.roomId);
 ```
-
-#### Properties
-
-- `event` : **object**
-
-  A collection of room events available to listen by accessing `room.event.<EVENT_NAME>`.
 
 #### Methods
 

--- a/packages/room/bandwidth-controller/bandwidth-controller.js
+++ b/packages/room/bandwidth-controller/bandwidth-controller.js
@@ -1,4 +1,5 @@
-import { PeerEvents } from '../peer/peer.js'
+import { InternalPeerEvents } from '../peer/peer.js'
+import { RoomEvent } from '../index.js'
 
 export class BandwidthController {
   #event
@@ -27,10 +28,10 @@ export class BandwidthController {
     this.#statsInterval = null
     this.#internalDataChannel = null
 
-    this.#event.on(PeerEvents.PEER_OPENED, this.#onPeerOpened)
-    this.#event.on(PeerEvents.PEER_CLOSED, this.#onPeerClosed)
+    this.#event.on(RoomEvent.PEER_OPENED, this.#onPeerOpened)
+    this.#event.on(RoomEvent.PEER_CLOSED, this.#onPeerClosed)
     this.#event.on(
-      PeerEvents._INTERNAL_DATACHANNEL_AVAILABLE,
+      InternalPeerEvents.INTERNAL_DATACHANNEL_AVAILABLE,
       this.#onInternalDataChannelAvailable
     )
   }

--- a/packages/room/channel/channel-types.d.ts
+++ b/packages/room/channel/channel-types.d.ts
@@ -16,11 +16,6 @@ export declare namespace RoomChannelType {
     streams: RoomStreamType.InstanceStreams
   }
 
-  type ChannelEvents = {
-    CHANNEL_OPENED: 'channelOpened'
-    CHANNEL_CLOSED: 'channelClosed'
-  }
-
   type TrackSource = {
     track_id: string
     source: string

--- a/packages/room/channel/channel.js
+++ b/packages/room/channel/channel.js
@@ -1,10 +1,4 @@
-import { PeerEvents } from '../peer/peer.js'
-
-/** @type {import('./channel-types.js').RoomChannelType.ChannelEvents} */
-export const ChannelEvents = {
-  CHANNEL_OPENED: 'channelOpened',
-  CHANNEL_CLOSED: 'channelClosed',
-}
+import { RoomEvent } from '../index.js'
 
 export const REASONS = {
   PEER_CLOSED: 'peerClosed',
@@ -41,8 +35,8 @@ export const createChannel = ({ api, event, peer, streams }) => {
       this._startTime = 0
       this._reconnecting = false
 
-      this._event.on(PeerEvents.PEER_OPENED, this._onPeerOpened)
-      this._event.on(PeerEvents.PEER_CLOSED, this._onPeerClosed)
+      this._event.on(RoomEvent.PEER_OPENED, this._onPeerOpened)
+      this._event.on(RoomEvent.PEER_CLOSED, this._onPeerClosed)
     }
 
     /**
@@ -111,7 +105,7 @@ export const createChannel = ({ api, event, peer, streams }) => {
       ) {
         this._reconnecting = true
         this.disconnect()
-        this._event.emit(ChannelEvents.CHANNEL_CLOSED, {
+        this._event.emit(RoomEvent.CHANNEL_CLOSED, {
           reason: REASONS.RECONNECT,
         })
         this.connect(this._roomId, this._clientId)
@@ -120,7 +114,7 @@ export const createChannel = ({ api, event, peer, streams }) => {
     }
 
     _onOpen = () => {
-      this._event.emit(ChannelEvents.CHANNEL_OPENED)
+      this._event.emit(RoomEvent.CHANNEL_OPENED)
     }
 
     _onError = async () => {
@@ -131,7 +125,7 @@ export const createChannel = ({ api, event, peer, streams }) => {
 
         if (response.code === 404) {
           this.disconnect()
-          this._event.emit(ChannelEvents.CHANNEL_CLOSED, {
+          this._event.emit(RoomEvent.CHANNEL_CLOSED, {
             reason: REASONS.NOT_FOUND,
           })
           return
@@ -161,7 +155,7 @@ export const createChannel = ({ api, event, peer, streams }) => {
 
     _onPeerClosed = () => {
       this.disconnect()
-      this._event.emit(ChannelEvents.CHANNEL_CLOSED, {
+      this._event.emit(RoomEvent.CHANNEL_CLOSED, {
         reason: REASONS.PEER_CLOSED,
       })
     }

--- a/packages/room/facade/facade-types.d.ts
+++ b/packages/room/facade/facade-types.d.ts
@@ -30,9 +30,5 @@ export declare namespace RoomFacadeType {
     channel: {
       createChannel: RoomChannelType.CreateChannel
     }
-    roomEvents: {
-      peer: RoomPeerType.PeerEvents
-      channel: RoomChannelType.ChannelEvents
-    }
   }
 }

--- a/packages/room/facade/facade.js
+++ b/packages/room/facade/facade.js
@@ -4,8 +4,8 @@ import { createApi } from '../api/api.js'
 import { createEvent } from '../event/event.js'
 import { createStreams } from '../stream/streams.js'
 import { createStream } from '../stream/stream.js'
-import { createPeer, PeerEvents } from '../peer/peer.js'
-import { createChannel, ChannelEvents } from '../channel/channel.js'
+import { createPeer } from '../peer/peer.js'
+import { createChannel } from '../channel/channel.js'
 import * as defaultConfig from '../config/config.js'
 
 const config = {
@@ -21,7 +21,6 @@ export const createFacade = ({
   stream: { createStream, createStreams },
   peer: { createPeer },
   channel: { createChannel },
-  roomEvents,
 }) => {
   return {
     /**
@@ -70,14 +69,6 @@ export const createFacade = ({
         on: event.on,
         leaveRoom: api.leaveRoom,
         endRoom: api.endRoom,
-        event: Object.freeze({
-          CHANNEL_OPENED: roomEvents.channel.CHANNEL_OPENED,
-          CHANNEL_CLOSED: roomEvents.channel.CHANNEL_CLOSED,
-          PEER_OPENED: roomEvents.peer.PEER_OPENED,
-          PEER_CLOSED: roomEvents.peer.PEER_CLOSED,
-          STREAM_AVAILABLE: roomEvents.peer.STREAM_AVAILABLE,
-          STREAM_REMOVED: roomEvents.peer.STREAM_REMOVED,
-        }),
       }
     },
   }
@@ -90,8 +81,4 @@ export const facade = createFacade({
   stream: { createStream, createStreams },
   peer: { createPeer },
   channel: { createChannel },
-  roomEvents: {
-    peer: PeerEvents,
-    channel: ChannelEvents,
-  },
 })

--- a/packages/room/index.js
+++ b/packages/room/index.js
@@ -1,5 +1,14 @@
 import { facade } from './facade/facade.js'
 
+export const RoomEvent = Object.freeze({
+  CHANNEL_OPENED: 'channelOpened',
+  CHANNEL_CLOSED: 'channelClosed',
+  PEER_OPENED: 'peerOpened',
+  PEER_CLOSED: 'peerClosed',
+  STREAM_AVAILABLE: 'streamAvailable',
+  STREAM_REMOVED: 'streamRemoved',
+})
+
 /**
  * @typedef {ReturnType<import('./facade/facade-types.js').RoomFacadeType.CreateInstanceFacade>} RoomInstance
  */

--- a/packages/room/peer/peer-types.d.ts
+++ b/packages/room/peer/peer-types.d.ts
@@ -38,15 +38,6 @@ export declare namespace RoomPeerType {
     config: RoomType.Config
   }
 
-  type PeerEvents = {
-    PEER_OPENED: 'peerOpened'
-    PEER_CLOSED: 'peerClosed'
-    STREAM_AVAILABLE: 'streamAvailable'
-    STREAM_REMOVED: 'streamRemoved'
-    _STREAM_ADDED: 'streamAdded'
-    _INTERNAL_DATACHANNEL_AVAILABLE: 'internalDataChannelAvailable'
-  }
-
   type RTCRtpSVCEncodingParameters = RTCRtpEncodingParameters & {
     scalabilityMode?: string
   }

--- a/packages/room/peer/peer.js
+++ b/packages/room/peer/peer.js
@@ -7,15 +7,11 @@ import {
 } from '../../internal/utils/get-browser-name.js'
 import { VideoObserver } from '../observer/video-observer.js'
 import { BandwidthController } from '../bandwidth-controller/bandwidth-controller.js'
+import { RoomEvent } from '../index.js'
 
-/** @type {import('./peer-types.js').RoomPeerType.PeerEvents} */
-export const PeerEvents = {
-  PEER_OPENED: 'peerOpened',
-  PEER_CLOSED: 'peerClosed',
-  STREAM_AVAILABLE: 'streamAvailable',
-  STREAM_REMOVED: 'streamRemoved',
-  _STREAM_ADDED: 'streamAdded',
-  _INTERNAL_DATACHANNEL_AVAILABLE: 'internalDataChannelAvailable',
+export const InternalPeerEvents = {
+  STREAM_ADDED: 'streamAdded',
+  INTERNAL_DATACHANNEL_AVAILABLE: 'internalDataChannelAvailable',
 }
 
 // This bitrate based on https://livekit.io/webrtc/bitrate-guide
@@ -73,7 +69,7 @@ export const createPeer = ({ api, createStream, event, streams, config }) => {
       })
 
       this._addEventListener()
-      this._event.emit(PeerEvents.PEER_OPENED, {
+      this._event.emit(RoomEvent.PEER_OPENED, {
         roomId: this._roomId,
         clientId: this._clientId,
       })
@@ -96,7 +92,7 @@ export const createPeer = ({ api, createStream, event, streams, config }) => {
       this._peerConnection = null
       this._roomId = ''
       this._clientId = ''
-      this._event.emit(PeerEvents.PEER_CLOSED)
+      this._event.emit(RoomEvent.PEER_CLOSED)
     }
 
     getClientId = () => {
@@ -119,7 +115,7 @@ export const createPeer = ({ api, createStream, event, streams, config }) => {
     addStream = (key, data) => {
       this._streams.validateKey(key)
       this._streams.validateStream(data)
-      this._event.emit(PeerEvents._STREAM_ADDED, { key, data })
+      this._event.emit(InternalPeerEvents.STREAM_ADDED, { key, data })
     }
 
     /**
@@ -132,7 +128,7 @@ export const createPeer = ({ api, createStream, event, streams, config }) => {
       const removedStream = this._streams.removeStream(key)
 
       if (removedStream) {
-        this._event.emit(PeerEvents.STREAM_REMOVED, { stream: removedStream })
+        this._event.emit(RoomEvent.STREAM_REMOVED, { stream: removedStream })
       }
 
       return removedStream
@@ -281,7 +277,7 @@ export const createPeer = ({ api, createStream, event, streams, config }) => {
 
       window.addEventListener('beforeunload', this._onBeforeUnload)
 
-      this._event.on(PeerEvents._STREAM_ADDED, this._onStreamAdded)
+      this._event.on(InternalPeerEvents.STREAM_ADDED, this._onStreamAdded)
     }
 
     _removeEventListener = () => {
@@ -612,7 +608,7 @@ export const createPeer = ({ api, createStream, event, streams, config }) => {
       if (event.channel.label === 'internal') {
         const internalChannel = event.channel
         this._event.emit(
-          PeerEvents._INTERNAL_DATACHANNEL_AVAILABLE,
+          InternalPeerEvents.INTERNAL_DATACHANNEL_AVAILABLE,
           internalChannel
         )
 
@@ -656,7 +652,7 @@ export const createPeer = ({ api, createStream, event, streams, config }) => {
         this._addLocalScreenStream(stream)
       }
 
-      this._event.emit(PeerEvents.STREAM_AVAILABLE, { stream })
+      this._event.emit(RoomEvent.STREAM_AVAILABLE, { stream })
     }
 
     /**


### PR DESCRIPTION
Based on the [discussion](https://github.com/asumsi/inlive-website/pull/232#discussion_r1386128373), we will change the way developers can get the room event list.

Previously, developers needs to create room object and access the event object
Example:
```js
import { Room } from '@inlivedev/inlive-js-sdk'
const room = Room()
room.event.{EVENT_NAME}
```

With current implementation, we export the event object separately. The sample usage as below.
Example:
```js
import { RoomEvent } from '@inlivedev/inlive-js-sdk'
RoomEvent.{EVENT_NAME}
```

