### PR TITLE
fix add ice candidate before setRemoteDescription

### DIFF
--- a/packages/room/channel/channel.js
+++ b/packages/room/channel/channel.js
@@ -163,15 +163,9 @@ export const createChannel = ({ api, event, peer, streams }) => {
     /**
      * @param {MessageEvent} event
      */
-    _onCandidate = async (event) => {
-      const peerConnection = this._peer.getPeerConnection()
-
-      if (!peerConnection || !peerConnection.remoteDescription) {
-        return
-      }
-
+    _onCandidate = (event) => {
       const candidate = new RTCIceCandidate(JSON.parse(event.data))
-      await peerConnection.addIceCandidate(candidate)
+      this._peer.addIceCandidate(candidate)
     }
 
     /**

--- a/packages/room/peer/peer-types.d.ts
+++ b/packages/room/peer/peer-types.d.ts
@@ -13,6 +13,7 @@ export declare namespace RoomPeerType {
     getRoomId: () => string
     getPeerConnection: () => RTCPeerConnection | null
     addStream: (key: string, value: RoomStreamType.StreamParameters) => void
+    addIceCandidate: (candidate: RTCIceCandidate) => void
     removeStream: (key: string) => RoomStreamType.InstanceStream | null
     getAllStreams: () => RoomStreamType.InstanceStream[]
     getStream: (key: string) => RoomStreamType.InstanceStream | null


### PR DESCRIPTION
The ice candidate may arrive earlier before SetRemoteDescription is called because the answer SDP is returned a bit late due to network or other things. The current implementation will just throw away that the candidate which will makes the connection will fail to connect.

The changes will add the candidate to the pending candidate when the remote SDP is not set yet. The pending candidates will be processed after setRemoteCandidate is successfully called.