### PR TITLE
add audio red support and enabled by default

### DIFF
--- a/packages/room/config/config.js
+++ b/packages/room/config/config.js
@@ -15,3 +15,21 @@ export const webrtc = {
     },
   ],
 }
+
+export const media = {
+  video: {
+    width: 1280,
+    height: 720,
+    frameRate: 24,
+    facingMode: 'user',
+    aspectRatio: 1.777_777_777_8,
+    maxBitrate: 1_200_000,
+    codec: 'VP9',
+  },
+  audio: {
+    echoCancellation: true,
+    noiseSuppression: true,
+    autoGainControl: true,
+    red: true,
+  },
+}

--- a/packages/room/facade/facade.js
+++ b/packages/room/facade/facade.js
@@ -11,6 +11,7 @@ import * as defaultConfig from '../config/config.js'
 const config = {
   api: defaultConfig.api,
   webrtc: defaultConfig.webrtc,
+  media: defaultConfig.media,
 }
 
 /** @param {import('./facade-types.js').RoomFacadeType.FacadeDependencies} facadeDependencies Dependencies for facade module */

--- a/packages/room/room-types.d.ts
+++ b/packages/room/room-types.d.ts
@@ -7,6 +7,24 @@ export declare namespace RoomType {
     webrtc: {
       iceServers: RTCIceServer[]
     }
+
+    media: {
+      video: {
+        width: number
+        height: number
+        frameRate: number
+        facingMode: string
+        aspectRatio: number
+        maxBitrate: number
+        codec: string
+      }
+      audio: {
+        echoCancellation: boolean
+        noiseSuppression: boolean
+        autoGainControl: boolean
+        red: boolean
+      }
+    }
   }
 
   type UserConfig = {


### PR DESCRIPTION
This PR enables audio red by default on SDK, which might add more bitrates on audio sent but it will improve the audio quality on bad network condition. Read more about it [here](https://webrtchacks.com/red-improving-audio-quality-with-redundancy/)