### PR TITLE
fix: fix type and functionality error after enabling get codec from room api

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,7 +2,7 @@
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "editor.formatOnSave": false,
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
+    "source.fixAll.eslint": "explicit"
   },
   "eslint.enable": true,
   "eslint.lintTask.enable": true,

--- a/packages/room/README.md
+++ b/packages/room/README.md
@@ -19,12 +19,12 @@ const room = Room({
 })
 ```
 
-### Authentication 
+### Authentication
 Some function in the Room Object require the apiKey parameter to be defined, since the SDK is designed to be used on Client and Server Side
 
 If the Library is used on the client side you might not need to pass the `apiKey` parameter
 
-The following function require apiKey to be defined : 
+The following function require apiKey to be defined :
 * `Room.createRoom()`
 * `Room.getRoom()`
 
@@ -68,7 +68,7 @@ await room.endRoom(roomData.data.roomId);
 
 #### Methods
 
-- `room.createRoom(name?: string | undefined, id?: string | undefined)` 
+- `room.createRoom(name?: string | undefined, id?: string | undefined)`
 
   > 🔐 Require ApiKey
 
@@ -140,7 +140,7 @@ const peer = await room.createPeer(roomData.data.roomId, client.data.clientId);
 const mediaStream = await navigator.mediaDevices.getUserMedia({ video: true, audio: true });
 
 // Add the user media input stream to the peer
-peer.addStream(mediaStream.id, {
+await peer.addStream(mediaStream.id, {
   clientId: client.data.clientId,
   name: 'Client A stream',
   origin: 'local', // local | remote
@@ -151,7 +151,7 @@ peer.addStream(mediaStream.id, {
 const displayScreen = await navigator.mediaDevices.getDisplayMedia({ video: true, audio: true });
 
 // Add the display screen media input stream to the peer
-peer.addStream(displayScreen.id, {
+await peer.addStream(displayScreen.id, {
   clientId: client.data.clientId,
   name: 'Screen by Client A',
   origin: 'local', // local | remote
@@ -212,7 +212,7 @@ peer.disconnect();
     - **source**: 'media' | 'screen'
     - **mediaStream**: MediaStream
 
-  A method to add and store a MediaStream object to the peer which returns a stream object. The benefit of storing and adding a MediaStream object to the peer is to keep track for every MediaStream available both from the local and remote peers. When the data `origin` value is `local`, it will try to reconfiguring the connection and trigger peer [negotiationneeded event](https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/negotiationneeded_event). It requires key which is an id or any key to help retrieving the data.
+  A method to add and store a MediaStream object to the peer which returns a stream object. The benefit of storing and adding a MediaStream object to the peer is to keep track for every MediaStream available both from the local and remote peers. When the data `origin` value is `local`, it will try to reconfiguring the connection and trigger peer [negotiationneeded event](https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/negotiationneeded_event). It requires key which is an id or any key to help retrieving the data. This method will return a promise.
 
 - `peer.removeStream(key)`
 

--- a/packages/room/api/fetcher.js
+++ b/packages/room/api/fetcher.js
@@ -18,7 +18,7 @@ export const createFetcher = () => {
      */
     _resolution = async (response) => {
       if (!response) {
-        throw new Error(`Cannot process response from the server`)
+        throw new Error(`No response received from the server.`)
       }
 
       const contentType = response.headers.get('content-type')
@@ -34,7 +34,10 @@ export const createFetcher = () => {
           throw new Error(`Cannot process response from the server: ${error}`)
         }
       } else {
-        throw new Error(`Cannot process response from the server`)
+        const textResponse = await response.text()
+        throw new Error(
+          `Cannot process response from the server. ${textResponse}.`
+        )
       }
     }
 

--- a/packages/room/api/fetcher.js
+++ b/packages/room/api/fetcher.js
@@ -36,7 +36,7 @@ export const createFetcher = () => {
       } else {
         const textResponse = await response.text()
         throw new Error(
-          `Cannot process response from the server. ${textResponse}.`
+          `Cannot process response from the server because of unsupported content-type. ${textResponse}.`
         )
       }
     }

--- a/packages/room/peer/peer-types.d.ts
+++ b/packages/room/peer/peer-types.d.ts
@@ -12,7 +12,7 @@ export declare namespace RoomPeerType {
     getClientId: () => string
     getRoomId: () => string
     getPeerConnection: () => RTCPeerConnection | null
-    addStream: (key: string, value: RoomStreamType.InstanceStream) => void
+    addStream: (key: string, value: RoomStreamType.AddStreamParameters) => void
     addIceCandidate: (candidate: RTCIceCandidate) => void
     removeStream: (key: string) => RoomStreamType.InstanceStream | null
     getAllStreams: () => RoomStreamType.InstanceStream[]

--- a/packages/room/peer/peer.js
+++ b/packages/room/peer/peer.js
@@ -340,14 +340,14 @@ export const createPeer = ({ api, createStream, event, streams, config }) => {
 
       if (!mediaTrack) return
 
-      for (const sender of peerConnection.getSenders()) {
-        if (!sender.track) return
+      const transceivers = peerConnection.getTransceivers()
 
-        if (
-          sender.track.kind === mediaTrack.kind &&
-          sender.track.id === mediaTrack.id
-        ) {
-          sender.track.enabled = enabled
+      for (const transceiver of transceivers) {
+        const track = transceiver.sender.track
+        if (!track) return
+
+        if (track.kind === mediaTrack.kind && track.id === mediaTrack.id) {
+          track.enabled = enabled
         }
       }
     }

--- a/packages/room/peer/peer.js
+++ b/packages/room/peer/peer.js
@@ -112,7 +112,7 @@ export const createPeer = ({ api, createStream, event, streams, config }) => {
      * @param {string} key
      * @param {import('../stream/stream-types.js').RoomStreamType.AddStreamParameters} data
      */
-    addStream = (key, data) => {
+    addStream = async (key, data) => {
       this._streams.validateKey(key)
       this._streams.validateStream(data)
 
@@ -124,7 +124,7 @@ export const createPeer = ({ api, createStream, event, streams, config }) => {
       this._streams.addStream(key, stream)
 
       if (stream.origin === 'local') {
-        this._addLocalMediaStream(stream)
+        await this._addLocalMediaStream(stream)
       }
 
       this._event.emit(RoomEvent.STREAM_AVAILABLE, { stream })
@@ -644,7 +644,7 @@ export const createPeer = ({ api, createStream, event, streams, config }) => {
 
       const draftStream = this._streams.getDraft(mediaStream.id) || {}
 
-      this.addStream(mediaStream.id, {
+      await this.addStream(mediaStream.id, {
         clientId: draftStream.clientId || '',
         name: draftStream.name || '',
         origin: draftStream.origin || 'remote',


### PR DESCRIPTION
## Changelogs
- `peer.addStream()` now asynchronous function to support asynchronous flow when adding local media stream.
- Readme about `peer.addStream()` was updated.
- Revert second parameter type for`peer.addStream()`. Use `AddStreamParameters` instead of `InstanceStream`
- Different fetching error message when no response or content-type is plain/text.
- Remove `STREAM_ADDED` internal-only event.