### PR TITLE
feat: enable to set the codec and bitrate preferences

### DIFF
--- a/packages/room/README.md
+++ b/packages/room/README.md
@@ -140,7 +140,7 @@ const peer = await room.createPeer(roomData.data.roomId, client.data.clientId);
 const mediaStream = await navigator.mediaDevices.getUserMedia({ video: true, audio: true });
 
 // Add the user media input stream to the peer
-await peer.addStream(mediaStream.id, {
+peer.addStream(mediaStream.id, {
   clientId: client.data.clientId,
   name: 'Client A stream',
   origin: 'local', // local | remote
@@ -151,7 +151,7 @@ await peer.addStream(mediaStream.id, {
 const displayScreen = await navigator.mediaDevices.getDisplayMedia({ video: true, audio: true });
 
 // Add the display screen media input stream to the peer
-await peer.addStream(displayScreen.id, {
+peer.addStream(displayScreen.id, {
   clientId: client.data.clientId,
   name: 'Screen by Client A',
   origin: 'local', // local | remote
@@ -212,7 +212,7 @@ peer.disconnect();
     - **source**: 'media' | 'screen'
     - **mediaStream**: MediaStream
 
-  A method to add and store a MediaStream object to the peer which returns a stream object. The benefit of storing and adding a MediaStream object to the peer is to keep track for every MediaStream available both from the local and remote peers. When the data `origin` value is `local`, it will try to reconfiguring the connection and trigger peer [negotiationneeded event](https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/negotiationneeded_event). It requires key which is an id or any key to help retrieving the data. This method will return a promise.
+  A method to add and store a MediaStream object to the peer which returns a stream object. The benefit of storing and adding a MediaStream object to the peer is to keep track for every MediaStream available both from the local and remote peers. When the data `origin` value is `local`, it will try to reconfiguring the connection and trigger peer [negotiationneeded event](https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/negotiationneeded_event). It requires key which is an id or any key to help retrieving the data.
 
 - `peer.removeStream(key)`
 

--- a/packages/room/README.md
+++ b/packages/room/README.md
@@ -104,7 +104,7 @@ await room.endRoom(roomData.data.roomId);
 
   A method to delete a specific room metadata based on metadata `key` provided. It expects the `roomId` and `key` as parameters. This method will return a promise.
 
-- `room.createPeer(roomId: string, clientId: string)`
+- `room.createPeer(roomId: string, clientId: string, config?: object)`
 
   A method to create a peer that manages the WebRTC peer to peer connection. It requires `roomId` and `clientId` parameters to be set. This method will return a promise.
 

--- a/packages/room/facade/facade.js
+++ b/packages/room/facade/facade.js
@@ -65,9 +65,10 @@ export const createFacade = ({
           /**
            * @param {string} roomId
            * @param {string} clientId
+           * @param {import('../peer/peer-types.js').RoomPeerType.PeerConfig} [config]
            */
-          async (roomId, clientId) => {
-            await peer.connect(roomId, clientId)
+          async (roomId, clientId, config) => {
+            await peer.connect(roomId, clientId, config)
             return peer
           },
         createDataChannel: api.createDataChannel,

--- a/packages/room/peer/peer-types.d.ts
+++ b/packages/room/peer/peer-types.d.ts
@@ -39,6 +39,17 @@ export declare namespace RoomPeerType {
     config: RoomType.Config
   }
 
+  type BitrateConfig = {
+    minBitrate?: number
+    midBitrate?: number
+    maxBitrate?: number
+  }
+
+  type PeerConfig = {
+    codecs?: string[]
+    bitrate?: BitrateConfig
+  }
+
   type RTCRtpSVCEncodingParameters = RTCRtpEncodingParameters & {
     scalabilityMode?: string
   }

--- a/packages/room/peer/peer.js
+++ b/packages/room/peer/peer.js
@@ -512,6 +512,7 @@ export const createPeer = ({ api, createStream, event, streams, config }) => {
           for (const videoCodec of videoCodecs) {
             if (videoCodec.mimeType === 'video/VP9') {
               videoPreferedCodecs.push(videoCodec)
+              svc = true
             }
           }
 

--- a/packages/room/peer/peer.js
+++ b/packages/room/peer/peer.js
@@ -145,7 +145,7 @@ export const createPeer = ({ api, createStream, event, streams, config }) => {
      * @param {string} key
      * @param {import('../stream/stream-types.js').RoomStreamType.AddStreamParameters} data
      */
-    addStream = async (key, data) => {
+    addStream = (key, data) => {
       this._streams.validateKey(key)
       this._streams.validateStream(data)
 
@@ -157,7 +157,7 @@ export const createPeer = ({ api, createStream, event, streams, config }) => {
       this._streams.addStream(key, stream)
 
       if (stream.origin === 'local') {
-        await this._addLocalMediaStream(stream)
+        this._addLocalMediaStream(stream)
       }
 
       this._event.emit(RoomEvent.STREAM_AVAILABLE, { stream })
@@ -421,7 +421,7 @@ export const createPeer = ({ api, createStream, event, streams, config }) => {
     /**
      * @param {import('../stream/stream-types.js').RoomStreamType.InstanceStream} stream
      */
-    _addLocalMediaStream = async (stream) => {
+    _addLocalMediaStream = (stream) => {
       if (!this._peerConnection) return
 
       /** @type {MediaStreamTrack | undefined} */
@@ -698,7 +698,7 @@ export const createPeer = ({ api, createStream, event, streams, config }) => {
 
       const draftStream = this._streams.getDraft(mediaStream.id) || {}
 
-      await this.addStream(mediaStream.id, {
+      this.addStream(mediaStream.id, {
         clientId: draftStream.clientId || '',
         name: draftStream.name || '',
         origin: draftStream.origin || 'remote',

--- a/packages/room/peer/peer.js
+++ b/packages/room/peer/peer.js
@@ -510,14 +510,14 @@ export const createPeer = ({ api, createStream, event, streams, config }) => {
           }
         } else {
           for (const videoCodec of videoCodecs) {
-            if (videoCodec.mimeType === 'video/H264') {
+            if (videoCodec.mimeType === 'video/VP9') {
               videoPreferedCodecs.push(videoCodec)
             }
           }
 
           // push the rest of the codecs
           for (const videoCodec of videoCodecs) {
-            if (videoCodec.mimeType !== 'video/H264') {
+            if (videoCodec.mimeType !== 'video/VP9') {
               videoPreferedCodecs.push(videoCodec)
             }
           }

--- a/packages/room/peer/peer.js
+++ b/packages/room/peer/peer.js
@@ -86,9 +86,9 @@ export const createPeer = ({ api, createStream, event, streams, config }) => {
         : []
 
       for (const codec of codecPreferences) {
-        if (codec.includes('audio')) {
+        if (codec.toLowerCase().includes('audio')) {
           this._audioCodecPreferences.push(codec)
-        } else if (codec.includes('video')) {
+        } else if (codec.toLowerCase().includes('video')) {
           this._videoCodecPreferences.push(codec)
         }
       }


### PR DESCRIPTION
## Changelogs
- `room.createPeer()` now accepts a config object as the third parameter. The config object consists of: 
  - `codecs`: codecs configurations. The value is the same as `codec_preferences` which is an array of mimetype string. When this codecs configuration not set, the default configuration will be:
    - For audio will use `audio/red` first, then continue with `audio/opus`.
    - For video will use `video/VP9` first, then put the rest of codecs
  - `bitrate`: bitrate object configurations. Consists of three bitrate configurations:
    1. maxBitrate: same as `bitrates.video_high` data from room. When not set, the default is 1200 * 1000.
    2. midBitrate: same as `bitrates.video_mid` data from room. When not set, the default is 500 * 1000.
    3. minBitrate: same as `bitrates.video_low` data from room. When not set, the default is 150 * 1000.
 - Remove async behavior on `peer.addStream()` function. Because this function no longer requesting `getRoom()` function when adding local stream. 