### PR TITLE
fix: handle unsupported codec and encoding

### DIFF
--- a/packages/room/peer/peer.js
+++ b/packages/room/peer/peer.js
@@ -475,7 +475,9 @@ export const createPeer = ({ api, createStream, event, streams, config }) => {
             }
           }
 
-          audioTsvr.setCodecPreferences(audioPreferedCodecs)
+          if ('setCodecPreferences' in audioTsvr) {
+            audioTsvr.setCodecPreferences(audioPreferedCodecs)
+          }
         }
 
         audioTrack.addEventListener('ended', () => {
@@ -582,7 +584,9 @@ export const createPeer = ({ api, createStream, event, streams, config }) => {
         ? this._peerConnection.addTransceiver(videoTrack, scaleableInit)
         : this._peerConnection.addTransceiver(videoTrack, simulcastInit)
 
-      tcvr.setCodecPreferences(videoPreferedCodecs)
+      if ('setCodecPreferences' in tcvr) {
+        tcvr.setCodecPreferences(videoPreferedCodecs)
+      }
 
       videoTrack.addEventListener('ended', () => {
         if (!this._peerConnection || !tcvr.sender) return

--- a/packages/room/peer/peer.js
+++ b/packages/room/peer/peer.js
@@ -4,6 +4,7 @@ import {
   EDGE,
   OPERA,
   SAFARI,
+  FIREFOX,
 } from '../../internal/utils/get-browser-name.js'
 import { VideoObserver } from '../observer/video-observer.js'
 import { BandwidthController } from '../bandwidth-controller/bandwidth-controller.js'
@@ -506,7 +507,10 @@ export const createPeer = ({ api, createStream, event, streams, config }) => {
               if (videoCodec.mimeType === videoCodecPreference) {
                 videoPreferedCodecs.push(videoCodec)
 
-                if (videoCodec.mimeType === 'video/VP9') {
+                if (
+                  videoCodec.mimeType === 'video/VP9' &&
+                  browserName !== FIREFOX
+                ) {
                   svc = true
                 }
               }
@@ -523,7 +527,10 @@ export const createPeer = ({ api, createStream, event, streams, config }) => {
           for (const videoCodec of videoCodecs) {
             if (videoCodec.mimeType === 'video/VP9') {
               videoPreferedCodecs.push(videoCodec)
-              svc = true
+
+              if (browserName !== FIREFOX) {
+                svc = true
+              }
             }
           }
 


### PR DESCRIPTION
## Changelogs
- Only call [`setCodecPreferences()`](https://developer.mozilla.org/en-US/docs/Web/API/RTCRtpTransceiver/setCodecPreferences) when the browser supports the method.
- Disable svc setting on firefox because firefox doesn't support svc encoding based on [livekit codecs guide](https://livekit.io/webrtc/codecs-guide).