### PR TITLE
fix: event allow_negotiation should be changed to allowed_renegotation

### DIFF
--- a/packages/room/channel/channel.js
+++ b/packages/room/channel/channel.js
@@ -85,8 +85,8 @@ export const createChannel = ({ api, event, peer, streams }) => {
       )
       this._channel.addEventListener('meta_changed', this._onMetaChanged)
       this._channel.addEventListener(
-        'allow_negotiation',
-        this._onAllowNegotiation
+        'allowed_renegotation',
+        this._onAllowedRenegotiation
       )
     }
 
@@ -104,8 +104,8 @@ export const createChannel = ({ api, event, peer, streams }) => {
       )
       this._channel.removeEventListener('meta_changed', this._onMetaChanged)
       this._channel.removeEventListener(
-        'allow_negotiation',
-        this._onAllowNegotiation
+        'allowed_renegotation',
+        this._onAllowedRenegotiation
       )
     }
 
@@ -315,9 +315,9 @@ export const createChannel = ({ api, event, peer, streams }) => {
       }
     }
 
-    _onAllowNegotiation = async () => {
+    _onAllowedRenegotiation = async () => {
       if (!this._roomId || !this._clientId) return
-      this._peer.negotiate()
+      await this._peer.negotiate()
     }
   }
 

--- a/packages/room/peer/peer-types.d.ts
+++ b/packages/room/peer/peer-types.d.ts
@@ -29,7 +29,7 @@ export declare namespace RoomPeerType {
     replaceTrack: (track: MediaStreamTrack) => Promise<void>
     observeVideo: (video: HTMLVideoElement) => void
     unobserveVideo: (video: HTMLVideoElement) => void
-    negotiate: () => void
+    negotiate: () => Promise<void>
     pendingNegotiation: boolean
   }
 


### PR DESCRIPTION
## Changelogs
- Fixes the client cannot listen for `allow_negotiation` SSE event because of wrong name. The correct SSE event name is `allowed_renegotation`
- Negotiation is triggered manually without listening the `negotiationneeded` event. 
