### PR TITLE
Fx video resize can't send resize info more than one video

### DIFF
--- a/packages/room/observer/video-observer-types.d.ts
+++ b/packages/room/observer/video-observer-types.d.ts
@@ -1,0 +1,7 @@
+import { VideoObserver } from './video-observer'
+
+export declare namespace VideoObserver {
+  interface StringMap {
+    [key: string]: number
+  }
+}


### PR DESCRIPTION
This PR should fix the video observer can't send video resized event more than one video element.