### PR TITLE
fix: register client require api key

### DIFF
--- a/packages/room/README.md
+++ b/packages/room/README.md
@@ -82,6 +82,8 @@ await room.endRoom(roomData.data.roomId);
 
 - `room.createClient(roomId: string, config?: object)`
 
+  > 🔐 Require ApiKey
+
   A method to create and register a new client to the room. It expects two parameters. The `roomId` is required. The second parameter is an optional config to set a custom client data. This method will return a promise.
 
 - `room.getClient(roomId: string, clientId: string)`

--- a/packages/room/api/api.js
+++ b/packages/room/api/api.js
@@ -115,8 +115,14 @@ export const createApi = ({ fetcher }) => {
         body.enable_vad = config.enableVAD
       }
 
-      const options =
-        body.uid || body.name ? { body: JSON.stringify(body) } : undefined
+      /** @type {RequestInit} */
+      const options = {
+        headers: { Authorization: 'Bearer ' + this._fetcher.getApiKey() },
+      }
+
+      if (body.uid || body.name) {
+        options.body = JSON.stringify(body)
+      }
 
       /** @type {import('./api-types.js').RoomAPIType.RegisterClientResponseBody} */
       const response = await this._fetcher.post(


### PR DESCRIPTION
To use the `createClient()` method, user needs to pass the API key