### PR TITLE
fix: Content-Type header was overwritten and removed unexpectedly by other headers input

### DIFF
--- a/packages/room/api/fetcher.js
+++ b/packages/room/api/fetcher.js
@@ -51,18 +51,19 @@ export const createFetcher = () => {
      * @param {RequestInit} [options]
      */
     _fetcher = (endpoint, options = {}) => {
-      const fetchOptions = typeof options === 'object' ? options : {}
-      const headersOptions =
-        typeof fetchOptions.headers === 'object' ? fetchOptions.headers : {}
+      options = typeof options === 'object' ? options : {}
+
+      /** @type {RequestInit} */
+      const init = {
+        ...options,
+        headers: {
+          'Content-Type': 'application/json',
+          ...(typeof options.headers === 'object' ? options.headers : {}),
+        },
+      }
 
       return globalThis
-        .fetch(`${this._baseUrl}${endpoint}`, {
-          headers: {
-            'Content-type': 'application/json; charset=utf-8',
-            ...headersOptions,
-          },
-          ...fetchOptions,
-        })
+        .fetch(`${this._baseUrl}${endpoint}`, init)
         .then(this._resolution)
         .catch(this._rejection)
     }


### PR DESCRIPTION
The `Content-Type` header was overwritten and removed when `Authorization` header was inputted into the fetcher option. This caused the fetcher would not be able to send body json data using `application/json` Content-Type. This PR fixes this issue 