### PR TITLE
adapt with room API endpoints

### DIFF
--- a/packages/room/api/api-types.d.ts
+++ b/packages/room/api/api-types.d.ts
@@ -1,5 +1,6 @@
 import type { createFetcher } from './fetcher.js'
 import type { createApi } from './api.js'
+import { RoomType } from '../room-types.js'
 
 export declare namespace RoomAPIType {
   type CreateFetcher = typeof createFetcher
@@ -42,28 +43,43 @@ export declare namespace RoomAPIType {
     initial_bandwidth: number
   }
 
+  type Options = {
+    bitrates: Bitrates
+    codecs: string[]
+    // empty room timeout in nanoseconds before the room is closed
+    empty_Room_timeout_ns: number
+    pli_interval_ns: number
+    quality_presets: RoomType.QualityPresets
+  }
+
+  type RoomRequest = {
+    id: string
+    name: string
+    options?: Options
+  }
+
+  type RoomResponse = {
+    id: string
+    name: string
+    options: Options
+  }
+
   type BaseResponseBody = {
     code: number
     ok: boolean
     message: string
   }
 
-  type CreateRoomResponseBody = BaseResponseBody & {
-    data: {
-      room_id: string
-      name: string
-      bitrate_configs: Bitrates
-      codec_preferences: string[]
-    }
+  type RoomCreateBody = BaseResponseBody & {
+    data: RoomRequest
   }
 
-  type GetRoomResponseBody = BaseResponseBody & {
-    data: {
-      room_id: string
-      name: string
-      bitrate_configs: Bitrates
-      codec_preferences: string[]
-    }
+  type RoomRespBody = BaseResponseBody & {
+    data: RoomResponse
+  }
+
+  type RoomReturnBody = BaseResponseBody & {
+    data: RoomType.Room
   }
 
   type RegisterClientResponseBody = BaseResponseBody & {

--- a/packages/room/api/api-types.d.ts
+++ b/packages/room/api/api-types.d.ts
@@ -1,6 +1,6 @@
 import type { createFetcher } from './fetcher.js'
 import type { createApi } from './api.js'
-import { RoomType } from '../room-types.js'
+import type { SharedType } from '../../internal/types/types.js'
 
 export declare namespace RoomAPIType {
   type CreateFetcher = typeof createFetcher
@@ -30,7 +30,20 @@ export declare namespace RoomAPIType {
     enable_vad?: boolean
   }
 
-  type Bitrates = {
+  type BitratesCamelCase = {
+    audioRed: number
+    audio: number
+    video: number
+    videoHigh: number
+    videoHighPixels: number
+    videoMid: number
+    videoMidPixels: number
+    videoLow: number
+    videoLowPixels: number
+    initialBandwidth: number
+  }
+
+  type BitratesSnakeCase = {
     audio: number
     audio_red: number
     video: number
@@ -43,25 +56,37 @@ export declare namespace RoomAPIType {
     initial_bandwidth: number
   }
 
-  type Options = {
-    bitrates: Bitrates
-    codecs: string[]
-    // empty room timeout in nanoseconds before the room is closed
-    empty_Room_timeout_ns: number
-    pli_interval_ns: number
-    quality_presets: RoomType.QualityPresets
+  type QualityPreset = {
+    sid: number
+    tid: number
   }
 
-  type RoomRequest = {
-    id: string
-    name: string
-    options?: Options
+  type QualityPresets = {
+    high: QualityPreset
+    low: QualityPreset
+    mid: QualityPreset
   }
+
+  type RoomOptions = {
+    bitrates: BitratesCamelCase
+    codecs: string[]
+    emptyRoomTimeoutMS: number
+    pliIntervalMS: number
+    qualityPresets: QualityPresets
+  }
+
+  type RoomUserOptions = SharedType.DeepPartial<RoomOptions>
 
   type RoomResponse = {
     id: string
     name: string
-    options: Options
+    options: {
+      bitrates: BitratesSnakeCase
+      codecs: string[]
+      empty_room_timeout_ns: number
+      pli_interval_ns: number
+      quality_presets: QualityPresets
+    }
   }
 
   type BaseResponseBody = {
@@ -70,23 +95,25 @@ export declare namespace RoomAPIType {
     message: string
   }
 
-  type RoomCreateBody = BaseResponseBody & {
-    data: RoomRequest
-  }
-
-  type RoomRespBody = BaseResponseBody & {
+  type RoomResponseBody = BaseResponseBody & {
     data: RoomResponse
   }
 
+  type Room = {
+    id: string
+    name: string
+    options: RoomOptions
+  }
+
   type RoomReturnBody = BaseResponseBody & {
-    data: RoomType.Room
+    data: Room
   }
 
   type RegisterClientResponseBody = BaseResponseBody & {
     data: {
       client_id: string
       name: string
-      bitrates: Bitrates
+      bitrates: BitratesSnakeCase
     }
   }
 
@@ -110,7 +137,7 @@ export declare namespace RoomAPIType {
     data: {
       client_id: string
       name: string
-      bitrates: Bitrates
+      bitrates: BitratesSnakeCase
     }
   }
 

--- a/packages/room/api/api.js
+++ b/packages/room/api/api.js
@@ -12,37 +12,83 @@ export const createApi = ({ fetcher }) => {
     /**
      * @param {string} [name]
      * @param {string} [id]
+     * @param {import('../room-types.js').RoomType.Options} [options]
+     * @returns {Promise<import('./api-types.js').RoomAPIType.RoomReturnBody>}
      */
-    createRoom = async (name = '', id = '') => {
-      /** @type {import('./api-types.js').RoomAPIType.CreateRoomResponseBody} */
+    createRoom = async (name = '', id = '', options) => {
+      const parameterOptions = {}
+      if (typeof options !== 'undefined') {
+        // map RoomType.Options to RoomAPIType.RoomOptions
+        if (typeof options.bitrates !== 'undefined') {
+          parameterOptions.bitrates = {
+            audio: options.bitrates.audio || 0,
+            audio_red: options.bitrates.audioRed || 0,
+            video: options.bitrates.video || 0,
+            video_high: options.bitrates.videoHigh || 0,
+            video_high_pixels: options.bitrates.videoHighPixels || 0,
+            video_mid: options.bitrates.videoMid || 0,
+            video_mid_pixels: options.bitrates.videoMidPixels || 0,
+            video_low: options.bitrates.videoLow || 0,
+            video_low_pixels: options.bitrates.videoLowPixels || 0,
+            initial_bandwidth: options.bitrates.initialBandwidth || 0,
+          }
+        }
+
+        if (typeof options.codecs !== 'undefined') {
+          parameterOptions.codecs = options.codecs || []
+        }
+
+        if (typeof options.pliIntervalMS !== 'undefined') {
+          parameterOptions.pli_interval_ns =
+            options.pliIntervalMS * 1_000_000 || 0
+        }
+
+        if (typeof options.emptyRoomTimeoutMS !== 'undefined') {
+          parameterOptions.empty_Room_timeout_ns =
+            options.emptyRoomTimeoutMS * 1_000_000 || 0
+        }
+
+        if (typeof options.qualityPresets !== 'undefined') {
+          parameterOptions.quality_presets = options.qualityPresets || {}
+        }
+      }
+
+      /** @type {import('./api-types.js').RoomAPIType.RoomRespBody} */
       const response = await this._fetcher.post(`/rooms/create`, {
         headers: { Authorization: 'Bearer ' + this._fetcher.getApiKey() },
-        body: JSON.stringify({ name, id }),
+        body: JSON.stringify({ name, id, parameterOptions }),
       })
 
       const data = response.data || {}
-      const bitrates = data.bitrate_configs || {}
+      const bitrates = data.options.bitrates || {}
 
+      /** @type {import('./api-types.js').RoomAPIType.RoomReturnBody} */
       const room = {
         code: response.code || 500,
         ok: response.ok || false,
         message: response.message || '',
         data: {
-          roomId: data.room_id || '',
-          roomName: data.name || '',
-          bitrates: {
-            audio: bitrates.audio || 0,
-            audioRed: bitrates.audio_red || 0,
-            video: bitrates.video || 0,
-            videoHigh: bitrates.video_high || 0,
-            videoHighPixels: bitrates.video_high_pixels || 0,
-            videoMid: bitrates.video_mid || 0,
-            videoMidPixels: bitrates.video_mid_pixels || 0,
-            videoLow: bitrates.video_low || 0,
-            videoLowPixels: bitrates.video_low_pixels || 0,
-            initialBandwidth: bitrates.initial_bandwidth || 0,
+          id: data.id || '',
+          name: data.name || '',
+          options: {
+            bitrates: {
+              audio: bitrates.audio || 0,
+              audioRed: bitrates.audio_red || 0,
+              video: bitrates.video || 0,
+              videoHigh: bitrates.video_high || 0,
+              videoHighPixels: bitrates.video_high_pixels || 0,
+              videoMid: bitrates.video_mid || 0,
+              videoMidPixels: bitrates.video_mid_pixels || 0,
+              videoLow: bitrates.video_low || 0,
+              videoLowPixels: bitrates.video_low_pixels || 0,
+              initialBandwidth: bitrates.initial_bandwidth || 0,
+            },
+            codecs: data.options.codecs || [],
+            pliIntervalMS: data.options.pli_interval_ns / 1_000_000 || 0,
+            emptyRoomTimeoutMS:
+              data.options.empty_Room_timeout_ns / 1_000_000 || 0,
+            qualityPresets: data.options.quality_presets || {},
           },
-          codecPreferences: data.codec_preferences || [],
         },
       }
 
@@ -51,40 +97,49 @@ export const createApi = ({ fetcher }) => {
 
     /**
      * @param {string} roomId
+     * @returns {Promise<import('./api-types.js').RoomAPIType.RoomReturnBody>}
      */
     getRoom = async (roomId) => {
       if (typeof roomId !== 'string' || roomId.trim().length === 0) {
         throw new Error('Room ID must be a valid string')
       }
 
-      /** @type {import('./api-types.js').RoomAPIType.GetRoomResponseBody} */
+      /** @type {import('./api-types.js').RoomAPIType.RoomRespBody} */
       const response = await this._fetcher.get(`/rooms/${roomId}`, {
         headers: { Authorization: 'Bearer ' + this._fetcher.getApiKey() },
       })
 
       const data = response.data || {}
-      const bitrates = data.bitrate_configs || {}
+      const bitrates = data.options.bitrates || {}
 
+      /** @type {import('./api-types.js').RoomAPIType.RoomReturnBody} */
+      /** @type {import('./api-types.js').RoomAPIType.RoomReturnBody} */
       const room = {
         code: response.code || 500,
         ok: response.ok || false,
         message: response.message || '',
         data: {
-          roomId: data.room_id || '',
-          roomName: data.name || '',
-          bitrates: {
-            audio: bitrates.audio || 0,
-            audioRed: bitrates.audio_red || 0,
-            video: bitrates.video || 0,
-            videoHigh: bitrates.video_high || 0,
-            videoHighPixels: bitrates.video_high_pixels || 0,
-            videoMid: bitrates.video_mid || 0,
-            videoMidPixels: bitrates.video_mid_pixels || 0,
-            videoLow: bitrates.video_low || 0,
-            videoLowPixels: bitrates.video_low_pixels || 0,
-            initialBandwidth: bitrates.initial_bandwidth || 0,
+          id: data.id || '',
+          name: data.name || '',
+          options: {
+            bitrates: {
+              audio: bitrates.audio || 0,
+              audioRed: bitrates.audio_red || 0,
+              video: bitrates.video || 0,
+              videoHigh: bitrates.video_high || 0,
+              videoHighPixels: bitrates.video_high_pixels || 0,
+              videoMid: bitrates.video_mid || 0,
+              videoMidPixels: bitrates.video_mid_pixels || 0,
+              videoLow: bitrates.video_low || 0,
+              videoLowPixels: bitrates.video_low_pixels || 0,
+              initialBandwidth: bitrates.initial_bandwidth || 0,
+            },
+            codecs: data.options.codecs || [],
+            pliIntervalMS: data.options.pli_interval_ns / 1_000_000 || 0,
+            emptyRoomTimeoutMS:
+              data.options.empty_Room_timeout_ns / 1_000_000 || 0,
+            qualityPresets: data.options.quality_presets || {},
           },
-          codecPreferences: data.codec_preferences || [],
         },
       }
 

--- a/packages/room/room-types.d.ts
+++ b/packages/room/room-types.d.ts
@@ -14,7 +14,7 @@ export declare namespace RoomType {
     media?: SharedType.DeepPartial<typeof media>
   }
 
-  type BitrateConfigs = {
+  type Bitrates = {
     audioRed: number
     audio: number
     video: number
@@ -27,10 +27,29 @@ export declare namespace RoomType {
     initialBandwidth: number
   }
 
+  type QualityPreset = {
+    sid: number
+    tid: number
+  }
+
+  type QualityPresets = {
+    high: QualityPreset
+    low: QualityPreset
+    mid: QualityPreset
+  }
+
+  type Options = {
+    bitrates?: Bitrates
+    codecs?: string[]
+    // empty room timeout in nanoseconds before the room is closed
+    emptyRoomTimeoutMS?: number
+    pliIntervalMS?: number
+    qualityPresets?: QualityPresets
+  }
+
   type Room = {
     id: string
     name: string
-    codecPreferences: string[]
-    bitrateConfigs: BitrateConfigs
+    options: Options
   }
 }

--- a/packages/room/room-types.d.ts
+++ b/packages/room/room-types.d.ts
@@ -13,43 +13,4 @@ export declare namespace RoomType {
     webrtc?: SharedType.DeepPartial<typeof webrtc>
     media?: SharedType.DeepPartial<typeof media>
   }
-
-  type Bitrates = {
-    audioRed: number
-    audio: number
-    video: number
-    videoHigh: number
-    videoHighPixels: number
-    videoMid: number
-    videoMidPixels: number
-    videoLow: number
-    videoLowPixels: number
-    initialBandwidth: number
-  }
-
-  type QualityPreset = {
-    sid: number
-    tid: number
-  }
-
-  type QualityPresets = {
-    high: QualityPreset
-    low: QualityPreset
-    mid: QualityPreset
-  }
-
-  type Options = {
-    bitrates?: Bitrates
-    codecs?: string[]
-    // empty room timeout in nanoseconds before the room is closed
-    emptyRoomTimeoutMS?: number
-    pliIntervalMS?: number
-    qualityPresets?: QualityPresets
-  }
-
-  type Room = {
-    id: string
-    name: string
-    options: Options
-  }
 }


### PR DESCRIPTION
There is a breaking changes API endpoint on room create and get basically both endpoints will have the same endpoint response like this:

```json
{
  "id": "string",
  "name": "string",
  "options": {
    "bitrates": {
      "audio": 48000,
      "audio_red": 75000,
      "initial_bandwidth": 1000000,
      "video": 1200000,
      "video_high": 1200000,
      "video_high_pixels": 921600,
      "video_low": 150000,
      "video_low_pixels": 64800,
      "video_mid": 500000,
      "video_mid_pixels": 259200
    },
    "codecs": [
      "video/VP9",
      "video/H264",
      "video/VP8",
      "audio/red",
      "audio/opus"
    ],
    "empty_room_timeout_ns": 300000000000,
    "pli_interval_ns": 0,
    "quality_presets": {
      "high": {
        "sid": 3,
        "tid": 3
      },
      "low": {
        "sid": 1,
        "tid": 1
      },
      "mid": {
        "sid": 2,
        "tid": 2
      }
    }
  }
}
```

This PR also will adapt the response with the SDK room type for example time type in API response will use nanoseconds but the SDK will use miliseconds for more frontend friendly time type.