### PR TITLE
fix: ensure "options" in the response data is not undefined when getting 404 room not found

### DIFF
--- a/packages/room/api/api.js
+++ b/packages/room/api/api.js
@@ -74,8 +74,9 @@ export const createApi = ({ fetcher }) => {
       })
 
       const data = response.data || {}
-      const bitrates = data.options?.bitrates || {}
-      const qualityPresets = data.options?.quality_presets || {}
+      const roomOptions = data.options || {}
+      const bitrates = roomOptions.bitrates || {}
+      const qualityPresets = roomOptions.quality_presets || {}
 
       /** @type {import('./api-types.js').RoomAPIType.RoomReturnBody} */
       const room = {
@@ -98,10 +99,10 @@ export const createApi = ({ fetcher }) => {
               videoLowPixels: bitrates.video_low_pixels || 0,
               initialBandwidth: bitrates.initial_bandwidth || 0,
             },
-            codecs: data.options.codecs || [],
-            pliIntervalMS: data.options.pli_interval_ns / 1_000_000 || 0,
+            codecs: roomOptions.codecs || [],
+            pliIntervalMS: roomOptions.pli_interval_ns / 1_000_000 || 0,
             emptyRoomTimeoutMS:
-              data.options.empty_room_timeout_ns / 1_000_000 || 0,
+              roomOptions.empty_room_timeout_ns / 1_000_000 || 0,
             qualityPresets: {
               high: {
                 sid: qualityPresets.high?.sid,
@@ -138,8 +139,9 @@ export const createApi = ({ fetcher }) => {
       })
 
       const data = response.data || {}
-      const bitrates = data.options?.bitrates || {}
-      const qualityPresets = data.options?.quality_presets || {}
+      const roomOptions = data.options || {}
+      const bitrates = roomOptions.bitrates || {}
+      const qualityPresets = roomOptions.quality_presets || {}
 
       /** @type {import('./api-types.js').RoomAPIType.RoomReturnBody} */
       const room = {
@@ -162,10 +164,10 @@ export const createApi = ({ fetcher }) => {
               videoLowPixels: bitrates.video_low_pixels || 0,
               initialBandwidth: bitrates.initial_bandwidth || 0,
             },
-            codecs: data.options.codecs || [],
-            pliIntervalMS: data.options.pli_interval_ns / 1_000_000 || 0,
+            codecs: roomOptions.codecs || [],
+            pliIntervalMS: roomOptions.pli_interval_ns / 1_000_000 || 0,
             emptyRoomTimeoutMS:
-              data.options.empty_room_timeout_ns / 1_000_000 || 0,
+              roomOptions.empty_room_timeout_ns / 1_000_000 || 0,
             qualityPresets: {
               high: {
                 sid: qualityPresets.high?.sid,


### PR DESCRIPTION
This PR fixes the `options` is undefined which crashed the function when room API returns 404 response and sdk tries to accessing the data inside the `options` object.

The default `getRoom()` response when trying to call 404 room will return option object like this
```js
options: {
    bitrates: {
      audio: 0,
      audioRed: 0,
      video: 0,
      videoHigh: 0,
      videoHighPixels: 0,
      videoMid: 0,
      videoMidPixels: 0,
      videoLow: 0,
      videoLowPixels: 0,
      initialBandwidth: 0
    },
    codecs: [],
    pliIntervalMS: 0,
    emptyRoomTimeoutMS: 0,
    qualityPresets: { 
      high: {
        sid: undefined,
        tid: undefined,
      }, 
      mid:{
        sid: undefined,
        tid: undefined,
      }, 
      low:{
        sid: undefined,
        tid: undefined,
      }
    }
  }
```