### PR TITLE
docs: add config options information

### DIFF
--- a/packages/room/README.md
+++ b/packages/room/README.md
@@ -21,6 +21,9 @@ const room = Room({
 ### Configurations
 These are the available config options for initializing the `Room` module. See the [default configuration](./config/config.js).
 
+> [!NOTE]
+Some webcam and screenshare configurations might not be always working the way they configured on every browser because each browser has different support for simulcast, svc, and codec.
+
 ```js
 {
   // API server configurations
@@ -82,9 +85,6 @@ These are the available config options for initializing the `Room` module. See t
   }
 }
 ```
-
-> [!NOTE]
-Some webcam and screenshare configurations might not be always working the way they configured on every browser because each browser has different support for simulcast, svc, and codec.
 
 ### Authentication
 Some function in the Room Object require the apiKey parameter to be defined, since the SDK is designed to be used on Client and Server Side

--- a/packages/room/README.md
+++ b/packages/room/README.md
@@ -100,12 +100,12 @@ Room({
 })
 ```
 
-2. Example of using H264 codec for webcam video codec with VP8 codec fallback, SVC is disabled, simulcast is enabled, and using L1T2 scalability mode.
+2. Example of using H264 codec for webcam video codec with VP8 or VP9 codecs fallback, SVC is disabled, simulcast is enabled, and using L1T2 scalability mode.
 ```js
 Room({
   // ...other options
   webcam: {
-    videoCodecs: ['video/H264', 'video/VP8'],
+    videoCodecs: ['video/H264', 'video/VP8', 'video/VP9'],
     simulcast: true,
     svc: false,
     scalabilityMode: 'L1T2',

--- a/packages/room/README.md
+++ b/packages/room/README.md
@@ -86,6 +86,33 @@ Some webcam and screenshare configurations might not be always working the way t
 }
 ```
 
+**Examples**
+1. Example of using VP9 codec for webcam video codec with H264 or VP8 codecs fallback, SVC is enabled, simulcast is disabled, and using L3T1 scalability mode.
+```js
+Room({
+  // ...other options
+  webcam: {
+    videoCodecs: ['video/VP9', 'video/H264', 'video/VP8'],
+    simulcast: false,
+    svc: true,
+    scalabilityMode: 'L3T1',
+  }
+})
+```
+
+2. Example of using H264 codec for webcam video codec with VP8 codec fallback, SVC is disabled, simulcast is enabled, and using L1T2 scalability mode.
+```js
+Room({
+  // ...other options
+  webcam: {
+    videoCodecs: ['video/H264', 'video/VP8'],
+    simulcast: true,
+    svc: false,
+    scalabilityMode: 'L1T2',
+  },
+})
+```
+
 ### Authentication
 Some function in the Room Object require the apiKey parameter to be defined, since the SDK is designed to be used on Client and Server Side
 

--- a/packages/room/README.md
+++ b/packages/room/README.md
@@ -83,6 +83,9 @@ These are the available config options for initializing the `Room` module. See t
 }
 ```
 
+> [!NOTE]
+Some webcam and screenshare configurations might not be always working the way they configured on every browser because each browser has different support for simulcast, svc, and codec.
+
 ### Authentication
 Some function in the Room Object require the apiKey parameter to be defined, since the SDK is designed to be used on Client and Server Side
 

--- a/packages/room/README.md
+++ b/packages/room/README.md
@@ -91,11 +91,13 @@ Some webcam and screenshare configurations might not be always working the way t
 ```js
 Room({
   // ...other options
-  webcam: {
-    videoCodecs: ['video/VP9', 'video/H264', 'video/VP8'],
-    simulcast: false,
-    svc: true,
-    scalabilityMode: 'L3T1',
+  media: {
+    webcam: {
+      videoCodecs: ['video/VP9', 'video/H264', 'video/VP8'],
+      simulcast: false,
+      svc: true,
+      scalabilityMode: 'L3T1',
+    }
   }
 })
 ```
@@ -104,11 +106,13 @@ Room({
 ```js
 Room({
   // ...other options
-  webcam: {
-    videoCodecs: ['video/H264', 'video/VP8', 'video/VP9'],
-    simulcast: true,
-    svc: false,
-    scalabilityMode: 'L1T2',
+  media: {
+    webcam: {
+      videoCodecs: ['video/H264', 'video/VP8', 'video/VP9'],
+      simulcast: true,
+      svc: false,
+      scalabilityMode: 'L1T2',
+    }
   }
 })
 ```

--- a/packages/room/README.md
+++ b/packages/room/README.md
@@ -4,7 +4,7 @@ This package is used to work with [inLive Hub and Room API services](https://hub
 
 ## Usage
 
-To use this package, you need to import a `Room()` module and initialize it in a global scope where you can export and import the room object returned everywhere in your application.
+To use this package, you need to import a `Room` module and initialize it in a global scope where you can export and import the room object returned everywhere in your application.
 
 ```js
 import { Room, RoomEvent } from '@inlivedev/inlive-js-sdk';
@@ -19,7 +19,7 @@ const room = Room({
 ```
 
 ### Configurations
-These are the available config options for initializing the `Room()` module. See the [default configuration](./config/config.js).
+These are the available config options for initializing the `Room` module. See the [default configuration](./config/config.js).
 
 ```js
 {
@@ -95,7 +95,7 @@ The following function require apiKey to be defined :
 
 ### Room object
 
-The room object is the object created when the `Room()` module is initialized. It consists methods that relates to the room scope. Some methods that directly interact to the room API can run on both client and server sides.
+The room object is the object created when the `Room` module is initialized. It consists methods that relates to the room scope. Some methods that directly interact to the room API can run on both client and server sides.
 
 #### Sample Code
 

--- a/packages/room/README.md
+++ b/packages/room/README.md
@@ -109,7 +109,7 @@ Room({
     simulcast: true,
     svc: false,
     scalabilityMode: 'L1T2',
-  },
+  }
 })
 ```
 

--- a/packages/room/README.md
+++ b/packages/room/README.md
@@ -86,7 +86,7 @@ Some webcam and screenshare configurations might not be always working the way t
 }
 ```
 
-**Examples**
+#### Examples
 1. Example of using VP9 codec for webcam video codec with H264 or VP8 codecs fallback, SVC is enabled, simulcast is disabled, and using L3T1 scalability mode.
 ```js
 Room({

--- a/packages/room/README.md
+++ b/packages/room/README.md
@@ -13,10 +13,74 @@ import { Room, RoomEvent } from '@inlivedev/inlive-js-sdk/dist/room.js';
 
 const room = Room({
   api : {
-    // Aditional parameter, required for some function
-    apiKey : YOUR_API_KEY
+    apiKey : 'YOUR_API_KEY'
   }
 })
+```
+
+### Configurations
+These are the available config options for initializing the `Room()` module. See the [default configuration](./config/config.js).
+
+```js
+{
+  // API server configurations
+  api: {
+    // This is the only required part when you want to use functions that require authentication.
+    apiKey: 'YOUR_API_KEY',
+
+    // The API server base URL
+    baseUrl: 'https://hub.inlive.app',
+
+    // The API server version
+    version: 'v1',
+  },
+
+  // WebRTC configurations
+  webrtc: {
+    // ICE servers used by the ICE agent
+    iceServers: []
+  },
+
+  // Media input configurations such as webcam, mic, and screenshare
+  media: {
+    webcam: {
+      // The maximum frame rate that can be used in frames per second
+      maxFramerate: 30,
+
+      // A list of preferred codecs for webcam in video MIME type format. Early codec in the list will be prioritized.
+      videoCodecs: ['video/VP9', 'video/H264', 'video/VP8'],
+
+      // Specify whether the simulcast is enabled for the webcam
+      simulcast: false,
+
+      // Specify whether the scalable video coding (svc) is enabled for the webcam
+      svc: true,
+
+      // Specify the scalability mode for the webcam
+      scalabilityMode: 'L3T1',
+    },
+    screen: {
+      // The maximum frame rate that can be used in frames per second
+      maxFramerate: 30,
+
+      // A list of preferred codecs for screenshare in video MIME type format. Early codec in the list will be prioritized.
+      videoCodecs: ['video/VP8', 'video/H264', 'video/VP9'],
+
+      // Specify whether the simulcast is enabled for the screenshare
+      simulcast: false,
+
+      // Specify whether the scalable video coding (svc) is enabled for the screenshare
+      svc: true,
+
+      // Specify the scalability mode for the screenshare
+      scalabilityMode: 'L1T2',
+    },
+    microphone: {
+      // A list of preferred codecs for microphone in audio MIME type format. Early codec in the list will be prioritized.
+      audioCodecs: ['audio/red', 'audio/opus'],
+    },
+  }
+}
 ```
 
 ### Authentication
@@ -27,6 +91,7 @@ If the Library is used on the client side you might not need to pass the `apiKey
 The following function require apiKey to be defined :
 * `Room.createRoom()`
 * `Room.getRoom()`
+* `Room.createClient()`
 
 ### Room object
 

--- a/packages/room/README.md
+++ b/packages/room/README.md
@@ -4,7 +4,7 @@ This package is used to work with [inLive Hub and Room API services](https://hub
 
 ## Usage
 
-To use this package, you need to import a `Room` module and initialize it in a global scope where you can export and import the room object returned everywhere in your application.
+To use this package, you need to import a `Room()` module and initialize it in a global scope where you can export and import the room object returned everywhere in your application.
 
 ```js
 import { Room, RoomEvent } from '@inlivedev/inlive-js-sdk';
@@ -95,7 +95,7 @@ The following function require apiKey to be defined :
 
 ### Room object
 
-The room object is the object created when the `Room` module is initialized. It consists methods that relates to the room scope. Some methods that directly interact to the room API can run on both client and server sides.
+The room object is the object created when the `Room()` module is initialized. It consists methods that relates to the room scope. Some methods that directly interact to the room API can run on both client and server sides.
 
 #### Sample Code
 


### PR DESCRIPTION
This PR adds the configuration section for the `Room()` module initialization in the README. Please see the [preview here](https://github.com/inlivedev/inlive-js-sdk/blob/doc/add-config-options/packages/room/README.md#configurations)