### PR TITLE
add bitrates to config and adjust the default to VP9 bitrates

### DIFF
--- a/packages/room/config/config.js
+++ b/packages/room/config/config.js
@@ -26,6 +26,11 @@ export const media = {
     simulcast: false,
     svc: true,
     scalabilityMode: 'L3T1',
+    bitrates: {
+      high: 700 * 1000,
+      mid: 300 * 1000,
+      low: 100 * 1000,
+    },
   },
   screen: {
     maxFramerate: 30,
@@ -33,6 +38,11 @@ export const media = {
     simulcast: false,
     svc: true,
     scalabilityMode: 'L1T2',
+    bitrates: {
+      high: 1200 * 1000,
+      mid: 500 * 1000,
+      low: 150 * 1000,
+    },
   },
   microphone: {
     audioCodecs: ['audio/red', 'audio/opus'],

--- a/packages/room/peer/peer.js
+++ b/packages/room/peer/peer.js
@@ -23,12 +23,6 @@ export const createPeer = ({ api, createStream, event, streams, config }) => {
     _bwController
     /** @type {VideoObserver | null} */
     _videoObserver
-    /** @type {number} */
-    _highBitrate
-    /** @type {number} */
-    _midBitrate
-    /** @type {number} */
-    _lowBitrate
     /** @type {Array<HTMLVideoElement>} */
     _pendingObservedVideo
     /** @type {Array<RTCIceCandidate>} */
@@ -49,9 +43,6 @@ export const createPeer = ({ api, createStream, event, streams, config }) => {
       })
 
       this._videoObserver = null
-      this._highBitrate = config.media.webcam.bitrates.high
-      this._midBitrate = config.media.webcam.bitrates.mid
-      this._lowBitrate = config.media.webcam.bitrates.low
       this._pendingObservedVideo = []
       this._pendingIceCandidates = []
       /**
@@ -552,16 +543,16 @@ export const createPeer = ({ api, createStream, event, streams, config }) => {
           preferredCodecs.push(videoCodec)
         }
 
-        const defaultBitrate =
-          type === 'webcam'
-            ? config.media.webcam.bitrates.high
-            : config.media.screen.bitrates.high
-
         /** @type {RTCRtpTransceiverInit} */
         const transceiverInit = {
           direction: 'sendonly',
           streams: [stream.mediaStream],
-          sendEncodings: [{ maxBitrate: defaultBitrate }],
+          sendEncodings: [
+            {
+              maxBitrate: config.media[type].bitrates.high,
+              maxFramerate: config.media[type].maxFramerate,
+            },
+          ],
         }
 
         const svcEnabled = config.media[type].svc && browserName !== FIREFOX
@@ -574,21 +565,21 @@ export const createPeer = ({ api, createStream, event, streams, config }) => {
             {
               rid: 'high',
               maxFramerate: config.media[type].maxFramerate,
-              maxBitrate: this._highBitrate,
+              maxBitrate: config.media[type].bitrates.high,
             },
             {
               rid: 'mid',
               // eslint-disable-next-line unicorn/no-zero-fractions
               scaleResolutionDownBy: 2.0,
               maxFramerate: config.media[type].maxFramerate,
-              maxBitrate: this._midBitrate,
+              maxBitrate: config.media[type].bitrates.mid,
             },
             {
               rid: 'low',
               // eslint-disable-next-line unicorn/no-zero-fractions
               scaleResolutionDownBy: 4.0,
               maxFramerate: config.media[type].maxFramerate,
-              maxBitrate: this._lowBitrate,
+              maxBitrate: config.media[type].bitrates.low,
             },
           ]
 
@@ -611,7 +602,7 @@ export const createPeer = ({ api, createStream, event, streams, config }) => {
             transceiverInit.sendEncodings = sendEncodings
           } else {
             const sendEncodings = {
-              maxBitrate: this._highBitrate,
+              maxBitrate: config.media[type].bitrates.high,
               scalabilityMode: config.media[type].scalabilityMode,
               maxFramerate: config.media[type].maxFramerate,
             }

--- a/packages/room/peer/peer.js
+++ b/packages/room/peer/peer.js
@@ -5,6 +5,7 @@ import {
 import { VideoObserver } from '../observer/video-observer.js'
 import { BandwidthController } from '../bandwidth-controller/bandwidth-controller.js'
 import { RoomEvent } from '../index.js'
+
 export const InternalPeerEvents = {
   INTERNAL_DATACHANNEL_AVAILABLE: 'internalDataChannelAvailable',
 }

--- a/packages/room/peer/peer.js
+++ b/packages/room/peer/peer.js
@@ -5,7 +5,6 @@ import {
 import { VideoObserver } from '../observer/video-observer.js'
 import { BandwidthController } from '../bandwidth-controller/bandwidth-controller.js'
 import { RoomEvent } from '../index.js'
-
 export const InternalPeerEvents = {
   INTERNAL_DATACHANNEL_AVAILABLE: 'internalDataChannelAvailable',
 }
@@ -50,9 +49,9 @@ export const createPeer = ({ api, createStream, event, streams, config }) => {
       })
 
       this._videoObserver = null
-      this._highBitrate = 1200 * 1000
-      this._midBitrate = 500 * 1000
-      this._lowBitrate = 150 * 1000
+      this._highBitrate = config.media.webcam.bitrates.high
+      this._midBitrate = config.media.webcam.bitrates.mid
+      this._lowBitrate = config.media.webcam.bitrates.low
       this._pendingObservedVideo = []
       this._pendingIceCandidates = []
       /**
@@ -553,10 +552,16 @@ export const createPeer = ({ api, createStream, event, streams, config }) => {
           preferredCodecs.push(videoCodec)
         }
 
+        const defaultBitrate =
+          type === 'webcam'
+            ? config.media.webcam.bitrates.high
+            : config.media.screen.bitrates.high
+
         /** @type {RTCRtpTransceiverInit} */
         const transceiverInit = {
           direction: 'sendonly',
           streams: [stream.mediaStream],
+          sendEncodings: [{ maxBitrate: defaultBitrate }],
         }
 
         const svcEnabled = config.media[type].svc && browserName !== FIREFOX


### PR DESCRIPTION
This PR add bitrate config to create peer function and set the default bitrate to 700kbps as we use VP9 as default bitrate. The default bitrate is taken from config parameter instead of hard coded. 