### PR TITLE
fix: empty string value on remote client id and client name

### DIFF
--- a/packages/room/channel/channel.js
+++ b/packages/room/channel/channel.js
@@ -273,24 +273,19 @@ export const createChannel = ({ api, event, peer, streams }) => {
 
       for (const id of Object.keys(data.tracks)) {
         const track = data.tracks[id]
-        const streamId = track.stream_id
-        const clientId = track.client_id
-        const clientName = track.client_name
-        const trackId = track.track_id
-        const source = track.source
 
         subscribingTracks.push({
-          client_id: clientId,
-          stream_id: streamId,
-          track_id: trackId,
+          client_id: track.client_id,
+          stream_id: track.stream_id,
+          track_id: track.track_id,
         })
 
         streams.push({
-          streamId: streamId,
-          clientId: clientId,
-          name: clientName,
+          streamId: track.stream_id,
+          clientId: track.client_id,
+          name: track.client_name,
           origin: 'remote',
-          source: source,
+          source: track.source,
         })
       }
 
@@ -312,16 +307,10 @@ export const createChannel = ({ api, event, peer, streams }) => {
             origin: stream.origin,
           }
 
-          const isValidStream = this._streams.validateStream(newStream)
-
-          if (isValidStream) {
-            this._event.emit(
-              InternalPeerEvents.REMOTE_STREAM_READY_TO_ADD,
-              newStream
-            )
-          } else {
-            this._streams.addDraft(stream.streamId, newStream)
-          }
+          this._event.emit(
+            InternalPeerEvents.REMOTE_STREAM_READY_TO_ADD,
+            newStream
+          )
         } else {
           this._streams.addDraft(stream.streamId, {
             clientId: stream.clientId,

--- a/packages/room/channel/channel.js
+++ b/packages/room/channel/channel.js
@@ -315,7 +315,10 @@ export const createChannel = ({ api, event, peer, streams }) => {
           const isValidStream = this._streams.validateStream(newStream)
 
           if (isValidStream) {
-            this._event.emit(InternalPeerEvents.REMOTE_STREAM_READY, newStream)
+            this._event.emit(
+              InternalPeerEvents.REMOTE_STREAM_READY_TO_ADD,
+              newStream
+            )
           } else {
             this._streams.addDraft(stream.streamId, newStream)
           }

--- a/packages/room/peer/peer.js
+++ b/packages/room/peer/peer.js
@@ -8,7 +8,7 @@ import { RoomEvent } from '../index.js'
 
 export const InternalPeerEvents = {
   INTERNAL_DATACHANNEL_AVAILABLE: 'internalDataChannelAvailable',
-  REMOTE_STREAM_READY: 'remoteStreamReady',
+  REMOTE_STREAM_READY_TO_ADD: 'remoteStreamReadyToAdd',
 }
 
 /** @param {import('./peer-types.js').RoomPeerType.PeerDependencies} peerDependencies Dependencies for peer module */
@@ -322,7 +322,7 @@ export const createPeer = ({ api, createStream, event, streams, config }) => {
       )
 
       this._event.on(
-        InternalPeerEvents.REMOTE_STREAM_READY,
+        InternalPeerEvents.REMOTE_STREAM_READY_TO_ADD,
         /** @param {import('../stream/stream-types.js').RoomStreamType.AddStreamParameters} stream */
         (stream) => {
           if (this.hasStream(stream.mediaStream.id)) return
@@ -787,7 +787,10 @@ export const createPeer = ({ api, createStream, event, streams, config }) => {
         const isValidStream = this._streams.validateStream(stream)
 
         if (isValidStream) {
-          this._event.emit(InternalPeerEvents.REMOTE_STREAM_READY, stream)
+          this._event.emit(
+            InternalPeerEvents.REMOTE_STREAM_READY_TO_ADD,
+            stream
+          )
         } else {
           this._streams.addDraft(streamId, stream)
         }

--- a/packages/room/stream/streams.js
+++ b/packages/room/stream/streams.js
@@ -142,7 +142,6 @@ export const createStreams = () => {
     /**
      * Validate the streams data
      * @param {import('./stream-types.js').RoomStreamType.AddStreamParameters} data
-     * @throws {Error}
      * @returns {boolean}
      */
     validateStream = (data) => {
@@ -154,9 +153,7 @@ export const createStreams = () => {
         typeof data.clientId !== 'string' ||
         typeof data.name !== 'string'
       ) {
-        throw new Error(
-          'Please provide valid stream data (clientId, name, origin, source, MediaStream)'
-        )
+        return false
       }
 
       return true


### PR DESCRIPTION
This PR will fix the issue of a remote stream data with empty client id and empty client name value because of race condition between `track` and `tracks_available` events. The SDK stored a remote stream too early on `track` event when the client ID and client name are still empty because `tracks_available` event was not triggered earlier than `track` event.

When `track` and `tracks_available` events are triggered, we will store the data we needed into a draft stream object. For example, we need a **mediaStream** object when `track` event is triggered, and we need **client ID**, **client Name**, stream **source** (media, screen) and stream **origin** when `tracks_available` event is triggered. Because the data are scattered, we need to combine them into one stream object first. If the whole data is ready, we can start storing the stream in our SDK and trigger the `STREAM_AVAILABLE` event to the user.

I also added internal SDK event `REMOTE_STREAM_READY_TO_ADD` this event is triggered when the remote draft stream is valid and ready to be stored in SDK