### PR TITLE
feat: update for on/off camera and mic media input

### DIFF
--- a/packages/room/README.md
+++ b/packages/room/README.md
@@ -435,29 +435,33 @@ peer.disconnect();
 
   A method to start sending video capture using local camera to other connected peers. A local stream object needs to be added with `peer.addStream()` before calling this method. This method will return a promise.
 
-  By default when the video track parameter is empty, the method will enable the local video track added with `peer.addStream()`. When the video track parameter is provided, SDK will try to use it as sender video track which sends the track to other connected peers.
+  By default when the video track parameter is empty, the method will enable the local video track added with `peer.addStream()`. When the video track parameter is provided, this method will try to use it as sender video track which sends the track to other connected peers.
 
-- `peer.turnOffCamera(videoTrack?: MediaStreamTrack | undefined)`
+- `peer.turnOffCamera(stop?: boolean | undefined)`
 
-  A method to stop sending the local video capture and stop the video capture track. You can provide which video capture track to stop as parameter. By default, when the video track parameter is empty, this method will find the video track added to SDK. Upon completion, this method will trigger `RoomEvent.TRACK_MUTE` event.
+  A method to stop sending local camera video capture to other connected peers. A local stream object needs to be added with `peer.addStream()` before calling this method.
 
-  When the video capture track is stopped, the track becomes unusable. You can get a new one with [getUserMedia()](https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getUserMedia).
+  By default when the `stop` track parameter is empty, the method will only disable the local video track added with `peer.addStream()`. The peer still sends empty blank frame to other connected peers. The device camera indicator may stay turning on.
 
-  After this method is called, the video of the peer which turns off the camera will become freeze on other peers side. The video freezes because the track's source is stopped and unable to provide data. Listen for `RoomEvent.TRACK_MUTE` to listen whether a video freezes when camera is turned off. You can provide an overlay UI which informs the user when a video freezes because the camera is turned off.
+  When the `stop` track parameter is provided, the method will completely stop sending the video track. After the track is stopped, the track becomes unusable. To start sending the video track again, call the `peer.turnOnCamera(newTrack)` method. You can get a new track again with [getUserMedia()](https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getUserMedia).
+
+  When the `stop` track parameter is provided, the video camera will become freeze on remote peers side because the track's source is stopped and unable to provide data. Listen for [track mute event](https://developer.mozilla.org/en-US/docs/Web/API/MediaStreamTrack/mute_event) to listen when the video freezes because its track is stopped.
 
 - `peer.turnOnMic(audioTrack?: MediaStreamTrack | undefined)`
 
   A method to start sending audio capture using local microphone to other connected peers. A local stream object needs to be added with `peer.addStream()` before calling this method. This method will return a promise.
 
-  By default when the audio track parameter is empty, the method will enable the local audio track added with `peer.addStream()`. When the audio track parameter is provided, SDK will try to use it as sender audio track which sends the track to other connected peers.
+  By default when the audio track parameter is empty, the method will enable the local audio track added with `peer.addStream()`. When the audio track parameter is provided, this method will try to use it as sender audio track which sends the track to other connected peers.
 
-- `peer.turnOffMic(audioTrack?: MediaStreamTrack | undefined)`
+- `peer.turnOffMic(stop?: boolean | undefined)`
 
-  A method to stop sending the local audio capture and stop the audio capture track. You can provide which audio capture track to stop as parameter. By default, when the audio track parameter is empty, this method will find the audio track added to SDK. Upon completion, this method will trigger `RoomEvent.TRACK_MUTE` event.
+  A method to stop sending local mic audio capture to other connected peers. A local stream object needs to be added with `peer.addStream()` before calling this method.
 
-  When the audio capture track is stopped, the track becomes unusable. You can get a new one with [getUserMedia()](https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getUserMedia).
+  By default when the `stop` track parameter is empty, the method will only disable the local audio track added with `peer.addStream()`. The peer still sends silence frame to other connected peers.
 
-  Listen for `RoomEvent.TRACK_MUTE` to listen whether a local or remote peer audio is mute/off.
+  When the `stop` track parameter is provided, the method will completely stop sending the audio track. After the track is stopped, the track becomes unusable. To start sending the audio track again, call the `peer.turnOnMic(newTrack)` method. You can get a new track again with [getUserMedia()](https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getUserMedia).
+
+  When the `stop` track parameter is provided, the audio track's source is stopped. Listen for [track mute event](https://developer.mozilla.org/en-US/docs/Web/API/MediaStreamTrack/mute_event) to listen when the audio track is stopped.
 
 - `peer.replaceTrack(track: MediaStreamTrack)`
 

--- a/packages/room/README.md
+++ b/packages/room/README.md
@@ -435,7 +435,7 @@ peer.disconnect();
 
   A method to start sending video capture using local camera to other connected peers. A local stream object needs to be added with `peer.addStream()` before calling this method. This method will return a promise.
 
-  By default when the video track parameter is empty, the method will enable the local video track added with `peer.addStream()`. When the video track parameter is provided, this method will use it as sender video track which sends the track to other connected peers.
+  By default when the video track parameter is empty, this method will enable the local video track added with `peer.addStream()`. When the video track parameter is provided, this method will use it as sender video track which sends the track to other connected peers.
 
   Listen for [track unmute event](https://developer.mozilla.org/en-US/docs/Web/API/MediaStreamTrack/unmute_event) to listen when a new remote video track is used.
 
@@ -443,9 +443,9 @@ peer.disconnect();
 
   A method to stop sending local camera video capture to other connected peers. A local stream object needs to be added with `peer.addStream()` before calling this method.
 
-  By default when the `stop` track parameter is empty, the method will only disable the local video track added with `peer.addStream()`. The peer still sends empty blank frame to other connected peers. The device camera indicator may stay turning on.
+  By default when the `stop` track parameter is empty, this method will only disable the local video track added with `peer.addStream()`. The peer still sends empty blank frame to other connected peers. The device camera indicator may stay turning on.
 
-  When the `stop` track parameter is provided, the method will completely stop sending the video track. After the track is stopped, the track becomes unusable. To start sending the video track again, call the `peer.turnOnCamera(newTrack)` method. You can get a new track again with [getUserMedia()](https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getUserMedia).
+  When the `stop` track parameter is provided, this method will completely stop sending the video track. After the track is stopped, the track becomes unusable. To start sending the video track again, call the `peer.turnOnCamera(newTrack)` method. You can get a new track again with [getUserMedia()](https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getUserMedia).
 
   When the `stop` track parameter is provided, the video camera will become freeze on remote peers side because the track's source is stopped and unable to provide data. Listen for [track mute event](https://developer.mozilla.org/en-US/docs/Web/API/MediaStreamTrack/mute_event) to listen when the remote video freezes because its track is stopped.
 
@@ -453,7 +453,7 @@ peer.disconnect();
 
   A method to start sending audio capture using local microphone to other connected peers. A local stream object needs to be added with `peer.addStream()` before calling this method. This method will return a promise.
 
-  By default when the audio track parameter is empty, the method will enable the local audio track added with `peer.addStream()`. When the audio track parameter is provided, this method will use it as sender audio track which sends the track to other connected peers.
+  By default when the audio track parameter is empty, this method will enable the local audio track added with `peer.addStream()`. When the audio track parameter is provided, this method will use it as sender audio track which sends the track to other connected peers.
 
   Listen for [track unmute event](https://developer.mozilla.org/en-US/docs/Web/API/MediaStreamTrack/unmute_event) to listen when a new remote audio track is used.
 
@@ -461,9 +461,9 @@ peer.disconnect();
 
   A method to stop sending local mic audio capture to other connected peers. A local stream object needs to be added with `peer.addStream()` before calling this method.
 
-  By default when the `stop` track parameter is empty, the method will only disable the local audio track added with `peer.addStream()`. The peer still sends silence frame to other connected peers.
+  By default when the `stop` track parameter is empty, this method will only disable the local audio track added with `peer.addStream()`. The peer still sends silence frame to other connected peers.
 
-  When the `stop` track parameter is provided, the method will completely stop sending the audio track. After the track is stopped, the track becomes unusable. To start sending the audio track again, call the `peer.turnOnMic(newTrack)` method. You can get a new track again with [getUserMedia()](https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getUserMedia).
+  When the `stop` track parameter is provided, this method will completely stop sending the audio track. After the track is stopped, the track becomes unusable. To start sending the audio track again, call the `peer.turnOnMic(newTrack)` method. You can get a new track again with [getUserMedia()](https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getUserMedia).
 
   When the `stop` track parameter is provided, the audio track's source is stopped. Listen for [track mute event](https://developer.mozilla.org/en-US/docs/Web/API/MediaStreamTrack/mute_event) to listen when the remote audio track is stopped.
 

--- a/packages/room/README.md
+++ b/packages/room/README.md
@@ -443,7 +443,7 @@ peer.disconnect();
 
   A method to stop sending local camera video capture to other connected peers. A local stream object needs to be added with `peer.addStream()` before calling this method.
 
-  By default when the `stop` track parameter is empty, this method will only disable the local video track added with `peer.addStream()`. The peer still sends empty blank frame to other connected peers. The device camera indicator may stay turning on.
+  By default when the `stop` track parameter is empty, this method will only disable the local video track added with `peer.addStream()`. The peer still sends empty blank frame to other connected peers. The device camera indicator may stay turning on. To reenable the video track, call `peer.turnOnCamera()`.
 
   When the `stop` track parameter is provided, this method will completely stop sending the video track. After the track is stopped, the track becomes unusable. To start sending the video track again, call the `peer.turnOnCamera(newTrack)` method. You can get a new track again with [getUserMedia()](https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getUserMedia).
 
@@ -461,7 +461,7 @@ peer.disconnect();
 
   A method to stop sending local mic audio capture to other connected peers. A local stream object needs to be added with `peer.addStream()` before calling this method.
 
-  By default when the `stop` track parameter is empty, this method will only disable the local audio track added with `peer.addStream()`. The peer still sends silence frame to other connected peers.
+  By default when the `stop` track parameter is empty, this method will only disable the local audio track added with `peer.addStream()`. The peer still sends silence frame to other connected peers. To reenable the audio track, call `peer.turnOnMic()`.
 
   When the `stop` track parameter is provided, this method will completely stop sending the audio track. After the track is stopped, the track becomes unusable. To start sending the audio track again, call the `peer.turnOnMic(newTrack)` method. You can get a new track again with [getUserMedia()](https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getUserMedia).
 

--- a/packages/room/README.md
+++ b/packages/room/README.md
@@ -439,7 +439,7 @@ peer.disconnect();
 
   Listen for [track unmute event](https://developer.mozilla.org/en-US/docs/Web/API/MediaStreamTrack/unmute_event) to listen when a new remote video track is used.
 
-  > When the video track parameter is provided and there is an existing sender video track, this method will replace the existing sender video track with the new track using [RTCRTPSender.replaceTrack()](https://developer.mozilla.org/en-US/docs/Web/API/RTCRtpSender/replaceTrack). There is a chance the track replacement will fail when the new track constraint is not the same with the existing track or this method is called in the wrong state of peer connection which will cause [exceptions](https://developer.mozilla.org/en-US/docs/Web/API/RTCRtpSender/replaceTrack#exceptions) to be thrown.
+  > When the video track parameter is provided and there is an existing sender video track, this method will replace the existing sender video track with the new track using [RTCRTPSender.replaceTrack()](https://developer.mozilla.org/en-US/docs/Web/API/RTCRtpSender/replaceTrack). There is a chance the track replacement may fail when the new track constraint is not the same with the existing track or this method is called in the wrong state of peer connection which will cause [exceptions](https://developer.mozilla.org/en-US/docs/Web/API/RTCRtpSender/replaceTrack#exceptions) to be thrown.
 
 - `peer.turnOffCamera(stop?: boolean | undefined)`
 
@@ -459,7 +459,7 @@ peer.disconnect();
 
   Listen for [track unmute event](https://developer.mozilla.org/en-US/docs/Web/API/MediaStreamTrack/unmute_event) to listen when a new remote audio track is used.
 
-    > When the audio track parameter is provided and there is an existing sender audio track, this method will replace the existing sender audio track with the new track using [RTCRTPSender.replaceTrack()](https://developer.mozilla.org/en-US/docs/Web/API/RTCRtpSender/replaceTrack). There is a chance the track replacement will fail when the new track constraint is not the same with the existing track or this method is called in the wrong state of peer connection which will cause [exceptions](https://developer.mozilla.org/en-US/docs/Web/API/RTCRtpSender/replaceTrack#exceptions) to be thrown.
+    > When the audio track parameter is provided and there is an existing sender audio track, this method will replace the existing sender audio track with the new track using [RTCRTPSender.replaceTrack()](https://developer.mozilla.org/en-US/docs/Web/API/RTCRtpSender/replaceTrack). There is a chance the track replacement may fail when the new track constraint is not the same with the existing track or this method is called in the wrong state of peer connection which will cause [exceptions](https://developer.mozilla.org/en-US/docs/Web/API/RTCRtpSender/replaceTrack#exceptions) to be thrown.
 
 - `peer.turnOffMic(stop?: boolean | undefined)`
 

--- a/packages/room/README.md
+++ b/packages/room/README.md
@@ -439,6 +439,8 @@ peer.disconnect();
 
   Listen for [track unmute event](https://developer.mozilla.org/en-US/docs/Web/API/MediaStreamTrack/unmute_event) to listen when a new remote video track is used.
 
+  > When the video track parameter is provided and there is an existing sender video track, this method will replace the existing sender video track with the new track using [RTCRTPSender.replaceTrack()](https://developer.mozilla.org/en-US/docs/Web/API/RTCRtpSender/replaceTrack). There is a chance the track replacement will fail when the new track constraint is not the same with the existing track or this method is called in the wrong state of peer connection which will cause [exceptions](https://developer.mozilla.org/en-US/docs/Web/API/RTCRtpSender/replaceTrack#exceptions) to be thrown.
+
 - `peer.turnOffCamera(stop?: boolean | undefined)`
 
   A method to stop sending local camera video capture to other connected peers. A local stream object needs to be added with `peer.addStream()` before calling this method.
@@ -456,6 +458,8 @@ peer.disconnect();
   By default when the audio track parameter is empty, this method will enable the local audio track added with `peer.addStream()`. When the audio track parameter is provided, this method will use it as sender audio track which sends the track to other connected peers.
 
   Listen for [track unmute event](https://developer.mozilla.org/en-US/docs/Web/API/MediaStreamTrack/unmute_event) to listen when a new remote audio track is used.
+
+    > When the audio track parameter is provided and there is an existing sender audio track, this method will replace the existing sender audio track with the new track using [RTCRTPSender.replaceTrack()](https://developer.mozilla.org/en-US/docs/Web/API/RTCRtpSender/replaceTrack). There is a chance the track replacement will fail when the new track constraint is not the same with the existing track or this method is called in the wrong state of peer connection which will cause [exceptions](https://developer.mozilla.org/en-US/docs/Web/API/RTCRtpSender/replaceTrack#exceptions) to be thrown.
 
 - `peer.turnOffMic(stop?: boolean | undefined)`
 

--- a/packages/room/README.md
+++ b/packages/room/README.md
@@ -433,21 +433,21 @@ peer.disconnect();
 
 - `peer.turnOnCamera(videoTrack?: MediaStreamTrack | undefined)`
 
-  A method to start sending video capture using local camera to other connected peers. You can provide a specific video track as parameter when calling this method. By default, when the video track parameter is empty, this method will use default local video setting to start sending video capture. This method will return a promise.
+  A method to start sending video capture using local camera to other connected peers. You can provide a specific video track as parameter when calling this method. By default, when the video track parameter is empty, this method will use default local video setting to start sending video capture. Upon completion, this method will trigger `RoomEvent.TRACK_UNMUTE` event. This method will return a promise.
 
 - `peer.turnOffCamera(videoTrack?: MediaStreamTrack | undefined)`
 
-  A method to stop sending the local video capture and stop the video capture track. You can provide which video capture track to stop as parameter. By default, when the video track parameter is empty, this method will find the video track added to SDK.
+  A method to stop sending the local video capture and stop the video capture track. You can provide which video capture track to stop as parameter. By default, when the video track parameter is empty, this method will find the video track added to SDK. Upon completion, this method will trigger `RoomEvent.TRACK_MUTE` event.
 
   When the video capture track is stopped, the track becomes unusable. You can get a new one with [getUserMedia()](https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getUserMedia).
 
 - `peer.turnOnMic(audioTrack?: MediaStreamTrack | undefined)`
 
-  A method to start sending audio capture using local microphone to other connected peers. You can provide a specific audio track as parameter when calling this method. By default, when the audio track parameter is empty, this method will use default local audio setting to start sending audio capture. This method will return a promise.
+  A method to start sending audio capture using local microphone to other connected peers. You can provide a specific audio track as parameter when calling this method. By default, when the audio track parameter is empty, this method will use default local audio setting to start sending audio capture. Upon completion, this method will trigger `RoomEvent.TRACK_UNMUTE` event. This method will return a promise.
 
 - `peer.turnOffMic(audioTrack?: MediaStreamTrack | undefined)`
 
-  A method to stop sending the local audio capture and stop the audio capture track. You can provide which audio capture track to stop as parameter. By default, when the audio track parameter is empty, this method will find the audio track added to SDK.
+  A method to stop sending the local audio capture and stop the audio capture track. You can provide which audio capture track to stop as parameter. By default, when the audio track parameter is empty, this method will find the audio track added to SDK. Upon completion, this method will trigger `RoomEvent.TRACK_MUTE` event.
 
   When the audio capture track is stopped, the track becomes unusable. You can get a new one with [getUserMedia()](https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getUserMedia).
 
@@ -505,3 +505,6 @@ The stream object holds read-only properties based on the provided client's data
 - `stream.addEventListener('voiceactivity', callback:function(ev:CustomEvent))`
 
   A custom event to listen for voice activity level changes. The callback function will receive a CustomEvent object with `detail` property that contains the the `audioLevel` value.
+
+
+### Guides

--- a/packages/room/README.md
+++ b/packages/room/README.md
@@ -435,21 +435,29 @@ peer.disconnect();
 
   A method to start sending video capture using local camera to other connected peers. You can provide a specific video track as parameter when calling this method. By default, when the video track parameter is empty, this method will use default local video setting to start sending video capture. Upon completion, this method will trigger `RoomEvent.TRACK_UNMUTE` event. This method will return a promise.
 
+  Listen for `RoomEvent.TRACK_UNMUTE` to listen whether a local or remote peer video is unmute/on.
+
 - `peer.turnOffCamera(videoTrack?: MediaStreamTrack | undefined)`
 
   A method to stop sending the local video capture and stop the video capture track. You can provide which video capture track to stop as parameter. By default, when the video track parameter is empty, this method will find the video track added to SDK. Upon completion, this method will trigger `RoomEvent.TRACK_MUTE` event.
 
   When the video capture track is stopped, the track becomes unusable. You can get a new one with [getUserMedia()](https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getUserMedia).
 
+  After this method is called, the video of the peer which turns off the camera will become freeze on other peers side. The video freezes because the track's source is stopped and unable to provide data. Listen for `RoomEvent.TRACK_MUTE` to listen whether a video freezes when camera is turned off. You can provide an overlay UI which informs the user when a video freezes because the camera is turned off.
+
 - `peer.turnOnMic(audioTrack?: MediaStreamTrack | undefined)`
 
   A method to start sending audio capture using local microphone to other connected peers. You can provide a specific audio track as parameter when calling this method. By default, when the audio track parameter is empty, this method will use default local audio setting to start sending audio capture. Upon completion, this method will trigger `RoomEvent.TRACK_UNMUTE` event. This method will return a promise.
+
+  Listen for `RoomEvent.TRACK_UNMUTE` to listen whether a local or remote peer audio is unmute/on.
 
 - `peer.turnOffMic(audioTrack?: MediaStreamTrack | undefined)`
 
   A method to stop sending the local audio capture and stop the audio capture track. You can provide which audio capture track to stop as parameter. By default, when the audio track parameter is empty, this method will find the audio track added to SDK. Upon completion, this method will trigger `RoomEvent.TRACK_MUTE` event.
 
   When the audio capture track is stopped, the track becomes unusable. You can get a new one with [getUserMedia()](https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getUserMedia).
+
+  Listen for `RoomEvent.TRACK_MUTE` to listen whether a local or remote peer audio is mute/off.
 
 - `peer.replaceTrack(track: MediaStreamTrack)`
 

--- a/packages/room/README.md
+++ b/packages/room/README.md
@@ -455,6 +455,10 @@ peer.disconnect();
 
   A method to replace the track currently being sent by sender with a new MediaStreamTrack.
 
+- `peer.negotiate()`
+
+  A method to trigger and start the manual negotiation process. This method will return a promise.
+
 
 #### Events
 
@@ -505,6 +509,3 @@ The stream object holds read-only properties based on the provided client's data
 - `stream.addEventListener('voiceactivity', callback:function(ev:CustomEvent))`
 
   A custom event to listen for voice activity level changes. The callback function will receive a CustomEvent object with `detail` property that contains the the `audioLevel` value.
-
-
-### Guides

--- a/packages/room/README.md
+++ b/packages/room/README.md
@@ -360,9 +360,9 @@ const streams = peer.getAllStreams();
 
 // After user media input is added, you can call these methods to turn on/off camera and mic
 peer.turnOffCamera();
-peer.turnOnCamera();
+await peer.turnOnCamera();
 peer.turnOffMic();
-peer.turnOnMic();
+await peer.turnOnMic();
 
 const peerConnection = peer.getPeerConnection();
 
@@ -431,21 +431,25 @@ peer.disconnect();
 
   A method to check if a specified stream object available and stored in the peer. It requires a key to find the data.
 
-- `peer.turnOnCamera()`
+- `peer.turnOnCamera(videoTrack?: MediaStreamTrack | undefined)`
 
-  A method to turn on the current local camera (video) track.
+  A method to start sending video capture using local camera to other connected peers. You can provide a specific video track as parameter when calling this method. By default, when the video track parameter is empty, this method will use default local video setting to start sending video capture. This method will return a promise.
 
-- `peer.turnOffCamera()`
+- `peer.turnOffCamera(videoTrack?: MediaStreamTrack | undefined)`
 
-  A method to turn off the current local camera (video) track.
+  A method to stop sending the local video capture and stop the video capture track. You can provide which video capture track to stop as parameter. By default, when the video track parameter is empty, this method will find the video track added to SDK.
 
-- `peer.turnOnMic()`
+  When the video capture track is stopped, the track becomes unusable. You can get a new one with [getUserMedia()](https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getUserMedia).
 
-  A method to turn on the current local microphone (audio) track.
+- `peer.turnOnMic(audioTrack?: MediaStreamTrack | undefined)`
 
-- `peer.turnOffMic()`
+  A method to start sending audio capture using local microphone to other connected peers. You can provide a specific audio track as parameter when calling this method. By default, when the audio track parameter is empty, this method will use default local audio setting to start sending audio capture. This method will return a promise.
 
-  A method to turn off the current local microphone (audio) track.
+- `peer.turnOffMic(audioTrack?: MediaStreamTrack | undefined)`
+
+  A method to stop sending the local audio capture and stop the audio capture track. You can provide which audio capture track to stop as parameter. By default, when the audio track parameter is empty, this method will find the audio track added to SDK.
+
+  When the audio capture track is stopped, the track becomes unusable. You can get a new one with [getUserMedia()](https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getUserMedia).
 
 - `peer.replaceTrack(track: MediaStreamTrack)`
 

--- a/packages/room/README.md
+++ b/packages/room/README.md
@@ -433,9 +433,9 @@ peer.disconnect();
 
 - `peer.turnOnCamera(videoTrack?: MediaStreamTrack | undefined)`
 
-  A method to start sending video capture using local camera to other connected peers. You can provide a specific video track as parameter when calling this method. By default, when the video track parameter is empty, this method will use default local video setting to start sending video capture. Upon completion, this method will trigger `RoomEvent.TRACK_UNMUTE` event. This method will return a promise.
+  A method to start sending video capture using local camera to other connected peers. A local stream object needs to be added with `peer.addStream()` before calling this method. This method will return a promise.
 
-  Listen for `RoomEvent.TRACK_UNMUTE` to listen whether a local or remote peer video is unmute/on.
+  By default when the video track parameter is empty, the method will enable the local video track added with `peer.addStream()`. When the video track parameter is provided, SDK will try to use it as sender video track which sends the track to other connected peers.
 
 - `peer.turnOffCamera(videoTrack?: MediaStreamTrack | undefined)`
 
@@ -447,9 +447,9 @@ peer.disconnect();
 
 - `peer.turnOnMic(audioTrack?: MediaStreamTrack | undefined)`
 
-  A method to start sending audio capture using local microphone to other connected peers. You can provide a specific audio track as parameter when calling this method. By default, when the audio track parameter is empty, this method will use default local audio setting to start sending audio capture. Upon completion, this method will trigger `RoomEvent.TRACK_UNMUTE` event. This method will return a promise.
+  A method to start sending audio capture using local microphone to other connected peers. A local stream object needs to be added with `peer.addStream()` before calling this method. This method will return a promise.
 
-  Listen for `RoomEvent.TRACK_UNMUTE` to listen whether a local or remote peer audio is unmute/on.
+  By default when the audio track parameter is empty, the method will enable the local audio track added with `peer.addStream()`. When the audio track parameter is provided, SDK will try to use it as sender audio track which sends the track to other connected peers.
 
 - `peer.turnOffMic(audioTrack?: MediaStreamTrack | undefined)`
 

--- a/packages/room/README.md
+++ b/packages/room/README.md
@@ -435,7 +435,9 @@ peer.disconnect();
 
   A method to start sending video capture using local camera to other connected peers. A local stream object needs to be added with `peer.addStream()` before calling this method. This method will return a promise.
 
-  By default when the video track parameter is empty, the method will enable the local video track added with `peer.addStream()`. When the video track parameter is provided, this method will try to use it as sender video track which sends the track to other connected peers.
+  By default when the video track parameter is empty, the method will enable the local video track added with `peer.addStream()`. When the video track parameter is provided, this method will use it as sender video track which sends the track to other connected peers.
+
+  Listen for [track unmute event](https://developer.mozilla.org/en-US/docs/Web/API/MediaStreamTrack/unmute_event) to listen when a new remote video track is used.
 
 - `peer.turnOffCamera(stop?: boolean | undefined)`
 
@@ -445,13 +447,15 @@ peer.disconnect();
 
   When the `stop` track parameter is provided, the method will completely stop sending the video track. After the track is stopped, the track becomes unusable. To start sending the video track again, call the `peer.turnOnCamera(newTrack)` method. You can get a new track again with [getUserMedia()](https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getUserMedia).
 
-  When the `stop` track parameter is provided, the video camera will become freeze on remote peers side because the track's source is stopped and unable to provide data. Listen for [track mute event](https://developer.mozilla.org/en-US/docs/Web/API/MediaStreamTrack/mute_event) to listen when the video freezes because its track is stopped.
+  When the `stop` track parameter is provided, the video camera will become freeze on remote peers side because the track's source is stopped and unable to provide data. Listen for [track mute event](https://developer.mozilla.org/en-US/docs/Web/API/MediaStreamTrack/mute_event) to listen when the remote video freezes because its track is stopped.
 
 - `peer.turnOnMic(audioTrack?: MediaStreamTrack | undefined)`
 
   A method to start sending audio capture using local microphone to other connected peers. A local stream object needs to be added with `peer.addStream()` before calling this method. This method will return a promise.
 
-  By default when the audio track parameter is empty, the method will enable the local audio track added with `peer.addStream()`. When the audio track parameter is provided, this method will try to use it as sender audio track which sends the track to other connected peers.
+  By default when the audio track parameter is empty, the method will enable the local audio track added with `peer.addStream()`. When the audio track parameter is provided, this method will use it as sender audio track which sends the track to other connected peers.
+
+  Listen for [track unmute event](https://developer.mozilla.org/en-US/docs/Web/API/MediaStreamTrack/unmute_event) to listen when a new remote audio track is used.
 
 - `peer.turnOffMic(stop?: boolean | undefined)`
 
@@ -461,7 +465,7 @@ peer.disconnect();
 
   When the `stop` track parameter is provided, the method will completely stop sending the audio track. After the track is stopped, the track becomes unusable. To start sending the audio track again, call the `peer.turnOnMic(newTrack)` method. You can get a new track again with [getUserMedia()](https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getUserMedia).
 
-  When the `stop` track parameter is provided, the audio track's source is stopped. Listen for [track mute event](https://developer.mozilla.org/en-US/docs/Web/API/MediaStreamTrack/mute_event) to listen when the audio track is stopped.
+  When the `stop` track parameter is provided, the audio track's source is stopped. Listen for [track mute event](https://developer.mozilla.org/en-US/docs/Web/API/MediaStreamTrack/mute_event) to listen when the remote audio track is stopped.
 
 - `peer.replaceTrack(track: MediaStreamTrack)`
 

--- a/packages/room/index.js
+++ b/packages/room/index.js
@@ -7,8 +7,6 @@ export const RoomEvent = Object.freeze({
   PEER_CLOSED: 'peerClosed',
   STREAM_AVAILABLE: 'streamAvailable',
   STREAM_REMOVED: 'streamRemoved',
-  TRACK_MUTE: 'trackMute',
-  TRACK_UNMUTE: 'trackUnmute',
   META_CHANGED: 'metaChanged',
 })
 

--- a/packages/room/index.js
+++ b/packages/room/index.js
@@ -7,10 +7,8 @@ export const RoomEvent = Object.freeze({
   PEER_CLOSED: 'peerClosed',
   STREAM_AVAILABLE: 'streamAvailable',
   STREAM_REMOVED: 'streamRemoved',
-  CAMERA_ON: 'cameraOn',
-  CAMERA_OFF: 'cameraOff',
-  MIC_ON: 'micOn',
-  MIC_OFF: 'micOff',
+  TRACK_MUTE: 'trackMute',
+  TRACK_UNMUTE: 'trackUnmute',
   META_CHANGED: 'metaChanged',
 })
 

--- a/packages/room/index.js
+++ b/packages/room/index.js
@@ -7,6 +7,10 @@ export const RoomEvent = Object.freeze({
   PEER_CLOSED: 'peerClosed',
   STREAM_AVAILABLE: 'streamAvailable',
   STREAM_REMOVED: 'streamRemoved',
+  CAMERA_ON: 'cameraOn',
+  CAMERA_OFF: 'cameraOff',
+  MIC_ON: 'micOn',
+  MIC_OFF: 'micOff',
   META_CHANGED: 'metaChanged',
 })
 

--- a/packages/room/peer/peer.js
+++ b/packages/room/peer/peer.js
@@ -488,26 +488,6 @@ export const createPeer = ({ api, createStream, event, streams, config }) => {
 
     /**
      * @param {MediaStreamTrack} track
-     */
-    _stopTrack = (track) => {
-      if (!this._peerConnection) return
-
-      if (!(track instanceof MediaStreamTrack)) {
-        throw new TypeError('Track must be an instance of MediaStreamTrack')
-      }
-
-      for (const transceiver of this._peerConnection.getTransceivers()) {
-        const senderTrack = transceiver.sender.track
-        if (!senderTrack) return
-
-        if (senderTrack.kind === track.kind && senderTrack.id === track.id) {
-          senderTrack.stop()
-        }
-      }
-    }
-
-    /**
-     * @param {MediaStreamTrack} track
      * @param {boolean} enabled
      */
     _setTrackEnabled = (track, enabled = true) => {
@@ -523,6 +503,26 @@ export const createPeer = ({ api, createStream, event, streams, config }) => {
 
         if (senderTrack.kind === track.kind && senderTrack.id === track.id) {
           senderTrack.enabled = enabled
+        }
+      }
+    }
+
+    /**
+     * @param {MediaStreamTrack} track
+     */
+    _stopTrack = (track) => {
+      if (!this._peerConnection) return
+
+      if (!(track instanceof MediaStreamTrack)) {
+        throw new TypeError('Track must be an instance of MediaStreamTrack')
+      }
+
+      for (const transceiver of this._peerConnection.getTransceivers()) {
+        const senderTrack = transceiver.sender.track
+        if (!senderTrack) return
+
+        if (senderTrack.kind === track.kind && senderTrack.id === track.id) {
+          senderTrack.stop()
         }
       }
     }

--- a/packages/room/peer/peer.js
+++ b/packages/room/peer/peer.js
@@ -248,12 +248,6 @@ export const createPeer = ({ api, createStream, event, streams, config }) => {
         this._addVideoTrack(track, localStream)
         await this.negotiate()
       }
-
-      this._event.emit(RoomEvent.TRACK_UNMUTE, {
-        track: track,
-        source: 'media',
-        origin: 'local',
-      })
     }
 
     /**
@@ -290,12 +284,6 @@ export const createPeer = ({ api, createStream, event, streams, config }) => {
         this._addAudioTrack(track, localStream)
         await this.negotiate()
       }
-
-      this._event.emit(RoomEvent.TRACK_UNMUTE, {
-        track: track,
-        source: 'media',
-        origin: 'local',
-      })
     }
 
     /**
@@ -439,26 +427,6 @@ export const createPeer = ({ api, createStream, event, streams, config }) => {
           })
 
           for (const track of stream.mediaStream.getTracks()) {
-            track.addEventListener('mute', (event) => {
-              const target = event.target
-              if (!(target instanceof MediaStreamTrack)) return
-              this._event.emit(RoomEvent.TRACK_MUTE, {
-                track: target,
-                source: stream.source,
-                origin: stream.origin,
-              })
-            })
-
-            track.addEventListener('unmute', (event) => {
-              const target = event.target
-              if (!(target instanceof MediaStreamTrack)) return
-              this._event.emit(RoomEvent.TRACK_UNMUTE, {
-                track: target,
-                source: stream.source,
-                origin: stream.origin,
-              })
-            })
-
             track.addEventListener('ended', () => {
               this.removeStream(stream.mediaStream.id)
             })

--- a/packages/room/peer/peer.js
+++ b/packages/room/peer/peer.js
@@ -339,6 +339,8 @@ export const createPeer = ({ api, createStream, event, streams, config }) => {
      * @param {MediaStreamTrack} [audioTrack] sender audio track
      */
     turnOffMic = (audioTrack) => {
+      if (!this._peerConnection) return
+
       if (audioTrack?.kind === 'audio') {
         this.stopTrack(audioTrack)
       } else {
@@ -1034,8 +1036,6 @@ export const createPeer = ({ api, createStream, event, streams, config }) => {
         turnOnMic: peer.turnOnMic,
         turnOffCamera: peer.turnOffCamera,
         turnOffMic: peer.turnOffMic,
-        addTrack: peer.addTrack,
-        stopTrack: peer.stopTrack,
         replaceTrack: peer.replaceTrack,
         observeVideo: peer.observeVideo,
         unobserveVideo: peer.unobserveVideo,

--- a/packages/room/peer/peer.js
+++ b/packages/room/peer/peer.js
@@ -231,6 +231,7 @@ export const createPeer = ({ api, createStream, event, streams, config }) => {
         if (localVideoTrack) {
           localStream.replaceTrack(newTrack)
           await this.replaceTrack(newTrack)
+          this._event.emit(RoomEvent.CAMERA_ON)
           return
         }
 
@@ -246,6 +247,7 @@ export const createPeer = ({ api, createStream, event, streams, config }) => {
         if (localVideoTrack) {
           localStream.replaceTrack(newTrack)
           await this.replaceTrack(newTrack)
+          this._event.emit(RoomEvent.CAMERA_ON)
           return
         }
 
@@ -276,6 +278,7 @@ export const createPeer = ({ api, createStream, event, streams, config }) => {
 
           if (track.kind === videoTrack.kind && track.id === videoTrack.id) {
             track.stop()
+            this._event.emit(RoomEvent.CAMERA_OFF)
           }
         }
       } else {
@@ -295,6 +298,7 @@ export const createPeer = ({ api, createStream, event, streams, config }) => {
 
           if (track.kind === videoTrack.kind && track.id === videoTrack.id) {
             track.stop()
+            this._event.emit(RoomEvent.CAMERA_OFF)
           }
         }
       }

--- a/packages/room/peer/peer.js
+++ b/packages/room/peer/peer.js
@@ -723,8 +723,6 @@ export const createPeer = ({ api, createStream, event, streams, config }) => {
         const systemVideoCodecs =
           RTCRtpReceiver.getCapabilities('video')?.codecs || []
 
-        console.log('systemVideoCodecs', systemVideoCodecs)
-
         for (const videoCodec of config.media[type].videoCodecs) {
           for (const systemVideoCodec of systemVideoCodecs) {
             if (
@@ -736,12 +734,9 @@ export const createPeer = ({ api, createStream, event, streams, config }) => {
           }
         }
 
-        console.log('preferredCodecs', preferredCodecs)
-
         // Add all remaining codecs
         for (const videoCodec of systemVideoCodecs) {
           if (!config.media[type].videoCodecs.includes(videoCodec.mimeType)) {
-            console.log('videoCodec', videoCodec)
             preferredCodecs.push(videoCodec)
           }
         }

--- a/packages/room/peer/peer.js
+++ b/packages/room/peer/peer.js
@@ -287,11 +287,17 @@ export const createPeer = ({ api, createStream, event, streams, config }) => {
      * @param {MediaStreamTrack} [stop] Completely stop the camera track
      */
     turnOffCamera = (stop) => {
-      const stream = this._streams.getAllStreams().find((stream) => {
+      const localStream = this._streams.getAllStreams().find((stream) => {
         return stream.origin === 'local' && stream.source === 'media'
       })
 
-      const videoTrack = stream?.mediaStream.getVideoTracks()[0]
+      if (!localStream || !(localStream.mediaStream instanceof MediaStream)) {
+        throw new Error(
+          'Add local media stream with addStream() before calling this method'
+        )
+      }
+
+      const videoTrack = localStream?.mediaStream.getVideoTracks()[0]
       if (!videoTrack) return
 
       if (stop) {
@@ -309,11 +315,17 @@ export const createPeer = ({ api, createStream, event, streams, config }) => {
      * @param {MediaStreamTrack} [stop] Completely stop the microphone track
      */
     turnOffMic = (stop) => {
-      const stream = this._streams.getAllStreams().find((stream) => {
+      const localStream = this._streams.getAllStreams().find((stream) => {
         return stream.origin === 'local' && stream.source === 'media'
       })
 
-      const audioTrack = stream?.mediaStream.getAudioTracks()[0]
+      if (!localStream || !(localStream.mediaStream instanceof MediaStream)) {
+        throw new Error(
+          'Add local media stream with addStream() before calling this method'
+        )
+      }
+
+      const audioTrack = localStream?.mediaStream.getAudioTracks()[0]
       if (!audioTrack) return
 
       if (stop) {

--- a/packages/room/peer/peer.js
+++ b/packages/room/peer/peer.js
@@ -322,7 +322,7 @@ export const createPeer = ({ api, createStream, event, streams, config }) => {
 
     /**
      * Turn off the local microphone
-     * @param {MediaStreamTrack} [stop] Completely stop the camera track
+     * @param {MediaStreamTrack} [stop] Completely stop the microphone track
      */
     turnOffMic = (stop) => {
       const stream = this._streams.getAllStreams().find((stream) => {

--- a/packages/room/peer/peer.js
+++ b/packages/room/peer/peer.js
@@ -253,6 +253,7 @@ export const createPeer = ({ api, createStream, event, streams, config }) => {
       }
 
       this._addVideoTrack(track, localStream)
+      await this.negotiate()
     }
 
     /**
@@ -294,6 +295,7 @@ export const createPeer = ({ api, createStream, event, streams, config }) => {
       }
 
       this._addAudioTrack(track, localStream)
+      await this.negotiate()
     }
 
     /**

--- a/packages/room/peer/peer.js
+++ b/packages/room/peer/peer.js
@@ -483,7 +483,7 @@ export const createPeer = ({ api, createStream, event, streams, config }) => {
 
       for (const transceiver of this._peerConnection.getTransceivers()) {
         const senderTrack = transceiver.sender.track
-        if (!senderTrack) return
+        if (!senderTrack) continue
 
         if (senderTrack.kind === track.kind && senderTrack.id === track.id) {
           senderTrack.enabled = enabled
@@ -503,7 +503,7 @@ export const createPeer = ({ api, createStream, event, streams, config }) => {
 
       for (const transceiver of this._peerConnection.getTransceivers()) {
         const senderTrack = transceiver.sender.track
-        if (!senderTrack) return
+        if (!senderTrack) continue
 
         if (senderTrack.kind === track.kind && senderTrack.id === track.id) {
           senderTrack.stop()

--- a/packages/room/peer/peer.js
+++ b/packages/room/peer/peer.js
@@ -229,24 +229,22 @@ export const createPeer = ({ api, createStream, event, streams, config }) => {
         )
       }
 
-      let track =
-        newTrack?.kind === 'video'
-          ? newTrack
-          : await navigator.mediaDevices
-              .getUserMedia({ video: true })
-              .then((stream) => stream.getVideoTracks()[0])
-              .catch((error) => {
-                throw error
-              })
+      const videoTrack = localStream.mediaStream.getVideoTracks()[0]
 
-      if (!track) return
+      if (newTrack) {
+        if (videoTrack) {
+          localStream.replaceTrack(newTrack)
+          await this.replaceTrack(newTrack)
+          return
+        }
 
-      if (localStream.mediaStream.getVideoTracks()[0]) {
-        localStream.replaceTrack(track)
-        await this.replaceTrack(track)
-      } else {
-        this._addVideoTrack(track, localStream)
+        this._addVideoTrack(newTrack, localStream)
         await this.negotiate()
+        return
+      }
+
+      if (videoTrack) {
+        this._setTrackEnabled(videoTrack, true)
       }
     }
 
@@ -265,24 +263,22 @@ export const createPeer = ({ api, createStream, event, streams, config }) => {
         )
       }
 
-      let track =
-        newTrack?.kind === 'audio'
-          ? newTrack
-          : await navigator.mediaDevices
-              .getUserMedia({ audio: true })
-              .then((stream) => stream.getAudioTracks()[0])
-              .catch((error) => {
-                throw error
-              })
+      const audioTrack = localStream.mediaStream.getAudioTracks()[0]
 
-      if (!track) return
+      if (newTrack) {
+        if (audioTrack) {
+          localStream.replaceTrack(newTrack)
+          await this.replaceTrack(newTrack)
+          return
+        }
 
-      if (localStream.mediaStream.getAudioTracks()[0]) {
-        localStream.replaceTrack(track)
-        await this.replaceTrack(track)
-      } else {
-        this._addAudioTrack(track, localStream)
+        this._addAudioTrack(newTrack, localStream)
         await this.negotiate()
+        return
+      }
+
+      if (audioTrack) {
+        this._setTrackEnabled(audioTrack, true)
       }
     }
 

--- a/packages/room/peer/peer.js
+++ b/packages/room/peer/peer.js
@@ -225,39 +225,30 @@ export const createPeer = ({ api, createStream, event, streams, config }) => {
         )
       }
 
-      const localVideoTrack = localStream.mediaStream.getVideoTracks()[0]
+      let track =
+        newTrack?.kind === 'video'
+          ? newTrack
+          : await navigator.mediaDevices
+              .getUserMedia({ video: true })
+              .then((stream) => stream.getVideoTracks()[0])
+              .catch((error) => {
+                throw error
+              })
 
-      if (newTrack?.kind === 'video') {
-        if (localVideoTrack) {
-          localStream.replaceTrack(newTrack)
-          await this.replaceTrack(newTrack)
-          this._event.emit(RoomEvent.TRACK_UNMUTE, {
-            track: newTrack,
-            source: 'media',
-            origin: 'local',
-          })
-        } else {
-          this.addTrack(newTrack, localStream)
-        }
-      } else {
-        const newTrack = await navigator.mediaDevices
-          .getUserMedia({ video: true })
-          .then((stream) => stream.getVideoTracks()[0])
+      if (!track) return
 
-        if (!newTrack) return
-
-        if (localVideoTrack) {
-          localStream.replaceTrack(newTrack)
-          await this.replaceTrack(newTrack)
-          this._event.emit(RoomEvent.TRACK_UNMUTE, {
-            track: newTrack,
-            source: 'media',
-            origin: 'local',
-          })
-        } else {
-          this.addTrack(newTrack, localStream)
-        }
+      if (localStream.mediaStream.getVideoTracks()[0]) {
+        localStream.replaceTrack(track)
+        await this.replaceTrack(track)
+        this._event.emit(RoomEvent.TRACK_UNMUTE, {
+          track: track,
+          source: 'media',
+          origin: 'local',
+        })
+        return
       }
+
+      this.addTrack(track, localStream)
     }
 
     /**
@@ -275,39 +266,30 @@ export const createPeer = ({ api, createStream, event, streams, config }) => {
         )
       }
 
-      const localAudioTrack = localStream.mediaStream.getAudioTracks()[0]
+      let track =
+        newTrack?.kind === 'audio'
+          ? newTrack
+          : await navigator.mediaDevices
+              .getUserMedia({ audio: true })
+              .then((stream) => stream.getAudioTracks()[0])
+              .catch((error) => {
+                throw error
+              })
 
-      if (newTrack?.kind === 'audio') {
-        if (localAudioTrack) {
-          localStream.replaceTrack(newTrack)
-          await this.replaceTrack(newTrack)
-          this._event.emit(RoomEvent.TRACK_UNMUTE, {
-            track: newTrack,
-            source: 'media',
-            origin: 'local',
-          })
-        } else {
-          this.addTrack(newTrack, localStream)
-        }
-      } else {
-        const newTrack = await navigator.mediaDevices
-          .getUserMedia({ audio: true })
-          .then((stream) => stream.getAudioTracks()[0])
+      if (!track) return
 
-        if (!newTrack) return
-
-        if (localAudioTrack) {
-          localStream.replaceTrack(newTrack)
-          await this.replaceTrack(newTrack)
-          this._event.emit(RoomEvent.TRACK_UNMUTE, {
-            track: newTrack,
-            source: 'media',
-            origin: 'local',
-          })
-        } else {
-          this.addTrack(newTrack, localStream)
-        }
+      if (localStream.mediaStream.getAudioTracks()[0]) {
+        localStream.replaceTrack(track)
+        await this.replaceTrack(track)
+        this._event.emit(RoomEvent.TRACK_UNMUTE, {
+          track: track,
+          source: 'media',
+          origin: 'local',
+        })
+        return
       }
+
+      this.addTrack(track, localStream)
     }
 
     /**

--- a/packages/room/peer/peer.js
+++ b/packages/room/peer/peer.js
@@ -88,7 +88,8 @@ export const createPeer = ({ api, createStream, event, streams, config }) => {
 
       for (const transceiver of this._peerConnection.getTransceivers()) {
         if (transceiver.sender.track) {
-          this.removeTrack(transceiver.sender.track)
+          transceiver.sender.track.stop()
+          this._peerConnection.removeTrack(transceiver.sender)
         }
 
         transceiver.stop()
@@ -377,8 +378,9 @@ export const createPeer = ({ api, createStream, event, streams, config }) => {
 
         if (transceiver) {
           newTrack.addEventListener('ended', () => {
-            if (!this._peerConnection || !transceiver.sender) return
-            this.removeTrack(newTrack)
+            if (!this._peerConnection || !transceiver.sender.track) return
+            transceiver.sender.track.stop()
+            this._peerConnection.removeTrack(transceiver.sender)
             this.removeStream(stream.id)
           })
         }
@@ -395,8 +397,9 @@ export const createPeer = ({ api, createStream, event, streams, config }) => {
 
         if (transceiver) {
           newTrack.addEventListener('ended', () => {
-            if (!this._peerConnection || !transceiver.sender) return
-            this.removeTrack(newTrack)
+            if (!this._peerConnection || !transceiver.sender.track) return
+            transceiver.sender.track.stop()
+            this._peerConnection.removeTrack(transceiver.sender)
             this.removeStream(stream.id)
           })
         }
@@ -424,32 +427,6 @@ export const createPeer = ({ api, createStream, event, streams, config }) => {
             source: 'media',
             origin: 'local',
           })
-        }
-      }
-    }
-
-    /**
-     * @param {MediaStreamTrack} track
-     */
-    removeTrack = (track) => {
-      if (!this._peerConnection) return
-
-      if (!(track instanceof MediaStreamTrack)) {
-        throw new TypeError('Track must be an instance of MediaStreamTrack')
-      }
-
-      for (const transceiver of this._peerConnection.getTransceivers()) {
-        const senderTrack = transceiver.sender.track
-        if (!senderTrack) return
-
-        if (senderTrack.kind === track.kind && senderTrack.id === track.id) {
-          senderTrack.stop()
-          this._peerConnection.removeTrack(transceiver.sender)
-          const stream = this.getStreamByTrackId(track.id)
-
-          if (stream) {
-            stream.mediaStream.removeTrack(track)
-          }
         }
       }
     }
@@ -1058,7 +1035,6 @@ export const createPeer = ({ api, createStream, event, streams, config }) => {
         turnOffCamera: peer.turnOffCamera,
         turnOffMic: peer.turnOffMic,
         addTrack: peer.addTrack,
-        removeTrack: peer.removeTrack,
         stopTrack: peer.stopTrack,
         replaceTrack: peer.replaceTrack,
         observeVideo: peer.observeVideo,

--- a/packages/room/peer/peer.js
+++ b/packages/room/peer/peer.js
@@ -300,38 +300,46 @@ export const createPeer = ({ api, createStream, event, streams, config }) => {
 
     /**
      * Turn off the local camera
-     * @param {MediaStreamTrack} [videoTrack] sender video track
+     * @param {MediaStreamTrack} [stop] Completely stop the camera track
      */
-    turnOffCamera = (videoTrack) => {
-      if (videoTrack?.kind === 'video') {
-        this._stopTrack(videoTrack)
-      } else {
-        const stream = this._streams.getAllStreams().find((stream) => {
-          return stream.origin === 'local' && stream.source === 'media'
-        })
-        const videoTrack = stream?.mediaStream.getVideoTracks()[0]
+    turnOffCamera = (stop) => {
+      const stream = this._streams.getAllStreams().find((stream) => {
+        return stream.origin === 'local' && stream.source === 'media'
+      })
 
-        if (!videoTrack) return
-        this._stopTrack(videoTrack)
+      const videoTrack = stream?.mediaStream.getVideoTracks()[0]
+      if (!videoTrack) return
+
+      if (stop) {
+        if (videoTrack.readyState === 'live') {
+          this._stopTrack(videoTrack)
+        }
+        return
       }
+
+      this._setTrackEnabled(videoTrack, false)
     }
 
     /**
      * Turn off the local microphone
-     * @param {MediaStreamTrack} [audioTrack] sender audio track
+     * @param {MediaStreamTrack} [stop] Completely stop the camera track
      */
-    turnOffMic = (audioTrack) => {
-      if (audioTrack?.kind === 'audio') {
-        this._stopTrack(audioTrack)
-      } else {
-        const stream = this._streams.getAllStreams().find((stream) => {
-          return stream.origin === 'local' && stream.source === 'media'
-        })
-        const audioTrack = stream?.mediaStream.getAudioTracks()[0]
+    turnOffMic = (stop) => {
+      const stream = this._streams.getAllStreams().find((stream) => {
+        return stream.origin === 'local' && stream.source === 'media'
+      })
 
-        if (!audioTrack) return
-        this._stopTrack(audioTrack)
+      const audioTrack = stream?.mediaStream.getAudioTracks()[0]
+      if (!audioTrack) return
+
+      if (stop) {
+        if (audioTrack.readyState === 'live') {
+          this._stopTrack(audioTrack)
+        }
+        return
       }
+
+      this._setTrackEnabled(audioTrack, false)
     }
 
     /**

--- a/packages/room/peer/peer.js
+++ b/packages/room/peer/peer.js
@@ -215,8 +215,6 @@ export const createPeer = ({ api, createStream, event, streams, config }) => {
      * @param {MediaStreamTrack} [newTrack] sender video track
      */
     turnOnCamera = async (newTrack) => {
-      if (!this._peerConnection) return
-
       const localStream = this.getAllStreams().find((stream) => {
         return stream.origin === 'local' && stream.source === 'media'
       })
@@ -267,8 +265,6 @@ export const createPeer = ({ api, createStream, event, streams, config }) => {
      * @param {MediaStreamTrack} [newTrack] sender audio track
      */
     turnOnMic = async (newTrack) => {
-      if (!this._peerConnection) return
-
       const localStream = this.getAllStreams().find((stream) => {
         return stream.origin === 'local' && stream.source === 'media'
       })
@@ -319,8 +315,6 @@ export const createPeer = ({ api, createStream, event, streams, config }) => {
      * @param {MediaStreamTrack} [videoTrack] sender video track
      */
     turnOffCamera = (videoTrack) => {
-      if (!this._peerConnection) return
-
       if (videoTrack?.kind === 'video') {
         this.stopTrack(videoTrack)
       } else {
@@ -339,8 +333,6 @@ export const createPeer = ({ api, createStream, event, streams, config }) => {
      * @param {MediaStreamTrack} [audioTrack] sender audio track
      */
     turnOffMic = (audioTrack) => {
-      if (!this._peerConnection) return
-
       if (audioTrack?.kind === 'audio') {
         this.stopTrack(audioTrack)
       } else {

--- a/packages/room/peer/peer.js
+++ b/packages/room/peer/peer.js
@@ -244,16 +244,16 @@ export const createPeer = ({ api, createStream, event, streams, config }) => {
       if (localStream.mediaStream.getVideoTracks()[0]) {
         localStream.replaceTrack(track)
         await this.replaceTrack(track)
-        this._event.emit(RoomEvent.TRACK_UNMUTE, {
-          track: track,
-          source: 'media',
-          origin: 'local',
-        })
-        return
+      } else {
+        this._addVideoTrack(track, localStream)
+        await this.negotiate()
       }
 
-      this._addVideoTrack(track, localStream)
-      await this.negotiate()
+      this._event.emit(RoomEvent.TRACK_UNMUTE, {
+        track: track,
+        source: 'media',
+        origin: 'local',
+      })
     }
 
     /**
@@ -286,16 +286,16 @@ export const createPeer = ({ api, createStream, event, streams, config }) => {
       if (localStream.mediaStream.getAudioTracks()[0]) {
         localStream.replaceTrack(track)
         await this.replaceTrack(track)
-        this._event.emit(RoomEvent.TRACK_UNMUTE, {
-          track: track,
-          source: 'media',
-          origin: 'local',
-        })
-        return
+      } else {
+        this._addAudioTrack(track, localStream)
+        await this.negotiate()
       }
 
-      this._addAudioTrack(track, localStream)
-      await this.negotiate()
+      this._event.emit(RoomEvent.TRACK_UNMUTE, {
+        track: track,
+        source: 'media',
+        origin: 'local',
+      })
     }
 
     /**

--- a/packages/room/peer/peer.js
+++ b/packages/room/peer/peer.js
@@ -341,6 +341,9 @@ export const createPeer = ({ api, createStream, event, streams, config }) => {
         throw new Error('Provide stream instance for track destination')
       }
 
+      /** @type {RTCRtpTransceiver | undefined} */
+      let transceiver
+
       if (newTrack.kind === 'video') {
         const videoTrack = stream.mediaStream.getVideoTracks()[0]
 
@@ -350,16 +353,7 @@ export const createPeer = ({ api, createStream, event, streams, config }) => {
           stream.replaceTrack(newTrack)
         }
 
-        const transceiver = this._addVideoTransceiver(stream)
-
-        if (transceiver) {
-          newTrack.addEventListener('ended', () => {
-            if (!this._peerConnection || !transceiver.sender.track) return
-            transceiver.sender.track.stop()
-            this._peerConnection.removeTrack(transceiver.sender)
-            this.removeStream(stream.id)
-          })
-        }
+        transceiver = this._addVideoTransceiver(stream)
       } else if (newTrack.kind === 'audio') {
         const audioTrack = stream.mediaStream.getAudioTracks()[0]
 
@@ -369,17 +363,15 @@ export const createPeer = ({ api, createStream, event, streams, config }) => {
           stream.replaceTrack(newTrack)
         }
 
-        const transceiver = this._addAudioTransceiver(stream)
-
-        if (transceiver) {
-          newTrack.addEventListener('ended', () => {
-            if (!this._peerConnection || !transceiver.sender.track) return
-            transceiver.sender.track.stop()
-            this._peerConnection.removeTrack(transceiver.sender)
-            this.removeStream(stream.id)
-          })
-        }
+        transceiver = this._addAudioTransceiver(stream)
       }
+
+      newTrack.addEventListener('ended', () => {
+        if (!this._peerConnection || !transceiver?.sender.track) return
+        transceiver.sender.track.stop()
+        this._peerConnection.removeTrack(transceiver.sender)
+        this.removeStream(stream.id)
+      })
     }
 
     /**

--- a/packages/room/peer/peer.js
+++ b/packages/room/peer/peer.js
@@ -292,10 +292,20 @@ export const createPeer = ({ api, createStream, event, streams, config }) => {
 
     /**
      * Turn off the local microphone
+     * @param {MediaStreamTrack} [audioTrack] sender audio track
      */
-    turnOffMic = () => {
-      if (!this._peerConnection) return
-      this._setTrackEnabled(this._peerConnection, 'audio', false)
+    turnOffMic = (audioTrack) => {
+      if (audioTrack?.kind === 'audio') {
+        this.stopTrack(audioTrack)
+      } else {
+        const stream = this._streams.getAllStreams().find((stream) => {
+          return stream.origin === 'local' && stream.source === 'media'
+        })
+        const audioTrack = stream?.mediaStream.getAudioTracks()[0]
+
+        if (!audioTrack) return
+        this.stopTrack(audioTrack)
+      }
     }
 
     /**

--- a/packages/room/peer/peer.js
+++ b/packages/room/peer/peer.js
@@ -243,14 +243,9 @@ export const createPeer = ({ api, createStream, event, streams, config }) => {
         }
 
         if (videoTrack) {
-          try {
-            await this.replaceTrack(newTrack)
-            localStream.replaceTrack(newTrack)
-            return
-          } catch (error) {
-            console.error(error)
-            throw error
-          }
+          await this.replaceTrack(newTrack)
+          localStream.replaceTrack(newTrack)
+          return
         }
 
         this._addVideoTrack(newTrack, localStream)
@@ -299,14 +294,9 @@ export const createPeer = ({ api, createStream, event, streams, config }) => {
         }
 
         if (audioTrack) {
-          try {
-            await this.replaceTrack(newTrack)
-            localStream.replaceTrack(newTrack)
-            return
-          } catch (error) {
-            console.error(error)
-            throw error
-          }
+          await this.replaceTrack(newTrack)
+          localStream.replaceTrack(newTrack)
+          return
         }
 
         this._addAudioTrack(newTrack, localStream)
@@ -399,7 +389,12 @@ export const createPeer = ({ api, createStream, event, streams, config }) => {
           transceiver.sender.track &&
           transceiver.sender.track.kind === newTrack.kind
         ) {
-          await transceiver.sender.replaceTrack(newTrack)
+          try {
+            await transceiver.sender.replaceTrack(newTrack)
+          } catch (error) {
+            console.error(error)
+            throw error
+          }
         }
       }
     }

--- a/packages/room/peer/peer.js
+++ b/packages/room/peer/peer.js
@@ -284,7 +284,7 @@ export const createPeer = ({ api, createStream, event, streams, config }) => {
 
     /**
      * Turn off the local camera
-     * @param {MediaStreamTrack} [stop] Completely stop the camera track
+     * @param {boolean} [stop] Completely stop the camera track
      */
     turnOffCamera = (stop) => {
       const localStream = this._streams.getAllStreams().find((stream) => {
@@ -312,7 +312,7 @@ export const createPeer = ({ api, createStream, event, streams, config }) => {
 
     /**
      * Turn off the local microphone
-     * @param {MediaStreamTrack} [stop] Completely stop the microphone track
+     * @param {boolean} [stop] Completely stop the microphone track
      */
     turnOffMic = (stop) => {
       const localStream = this._streams.getAllStreams().find((stream) => {

--- a/packages/room/peer/peer.js
+++ b/packages/room/peer/peer.js
@@ -231,7 +231,11 @@ export const createPeer = ({ api, createStream, event, streams, config }) => {
         if (localVideoTrack) {
           localStream.replaceTrack(newTrack)
           await this.replaceTrack(newTrack)
-          this._event.emit(RoomEvent.CAMERA_ON)
+          this._event.emit(RoomEvent.TRACK_UNMUTE, {
+            track: newTrack,
+            source: 'media',
+            origin: 'local',
+          })
           return
         }
 
@@ -247,7 +251,11 @@ export const createPeer = ({ api, createStream, event, streams, config }) => {
         if (localVideoTrack) {
           localStream.replaceTrack(newTrack)
           await this.replaceTrack(newTrack)
-          this._event.emit(RoomEvent.CAMERA_ON)
+          this._event.emit(RoomEvent.TRACK_UNMUTE, {
+            track: newTrack,
+            source: 'media',
+            origin: 'local',
+          })
           return
         }
 
@@ -278,7 +286,11 @@ export const createPeer = ({ api, createStream, event, streams, config }) => {
 
           if (track.kind === videoTrack.kind && track.id === videoTrack.id) {
             track.stop()
-            this._event.emit(RoomEvent.CAMERA_OFF)
+            this._event.emit(RoomEvent.TRACK_MUTE, {
+              track: track,
+              source: 'media',
+              origin: 'local',
+            })
           }
         }
       } else {
@@ -298,7 +310,11 @@ export const createPeer = ({ api, createStream, event, streams, config }) => {
 
           if (track.kind === videoTrack.kind && track.id === videoTrack.id) {
             track.stop()
-            this._event.emit(RoomEvent.CAMERA_OFF)
+            this._event.emit(RoomEvent.TRACK_MUTE, {
+              track: track,
+              source: 'media',
+              origin: 'local',
+            })
           }
         }
       }
@@ -409,6 +425,26 @@ export const createPeer = ({ api, createStream, event, streams, config }) => {
           })
 
           for (const track of stream.mediaStream.getTracks()) {
+            track.addEventListener('mute', (event) => {
+              const target = event.target
+              if (!(target instanceof MediaStreamTrack)) return
+              this._event.emit(RoomEvent.TRACK_MUTE, {
+                track: target,
+                source: stream.source,
+                origin: stream.origin,
+              })
+            })
+
+            track.addEventListener('unmute', (event) => {
+              const target = event.target
+              if (!(target instanceof MediaStreamTrack)) return
+              this._event.emit(RoomEvent.TRACK_UNMUTE, {
+                track: target,
+                source: stream.source,
+                origin: stream.origin,
+              })
+            })
+
             track.addEventListener('ended', () => {
               this.removeStream(stream.mediaStream.id)
             })


### PR DESCRIPTION
## Description

This PR will add additional behaviour for `turnOnCamera()`, `turnOffCamera()`, `turnOnMic()`, `turnOffMic()` methods.

### Previous behaviour

Previously the behaviour those methods were just toggling the [enabled](https://developer.mozilla.org/en-US/docs/Web/API/MediaStreamTrack/enabled) property of the video and audio MediaStreamTracks. This would send an empty 0 frame as an output. This worked by muting the audio and making the video blank. However, the camera indicator was still turning on which might made the user concern whether the camera was actually turned off or still turned on.

### Current behaviour

These are the current behaviour for those methods:

- `peer.turnOnCamera(videoTrack?: MediaStreamTrack | undefined)`
  
  By default when the video track parameter is empty, the method will enable the video track. When the video track parameter is provided, SDK will try to use the new video track as sender video track which sends the track to other connected peers.

  Before calling this method, a local stream object needs to be added with `peer.addStream()` to make it works:
  - When the track parameter is provided and local stream has a sender video track, the method will replace the sender track with the new one.
  - When the track parameter is provided and local stream doesn't have a sender video track, the method will add the video track to the sender. SDK will automatically renegotiate.

- `peer.turnOnMic(audioTrack?: MediaStreamTrack | undefined)`

  By default when the audio track parameter is empty, the method will enable the audio track. When the audio track parameter is provided, SDK will try to use the new audio track as sender audio track which sends the track to other connected peers.

  Before calling this method, a local stream object needs to be added with `peer.addStream()` to make it works:
  - When the track parameter is provided and local stream has a sender audio track, the method will replace the sender track with the new one.
  - When the track parameter is provided and local stream doesn't have a sender audio track, the method will add the audio track to the sender. SDK will automatically renegotiate.

- `peer.turnOffCamera(stop?: boolean | undefined)`

  By default when the `stop` boolean indicator is empty or false, the method will disable and mute the video track. SDK will still send empty frame and the camera video track is still not stopped.
  
  When the `stop` boolean indicator set to true, the method will stop the camera video capture track. The track becomes unusable, device camera lamp indicator will turn off, and when turning on the video capture track again will require calling `peer.turnOnCamera(newTrack)`.

- `peer.turnOffMic(stop?: boolean | undefined)`

  By default when the `stop` boolean indicator is empty or false, the method will disable and mute the audio track. SDK will send silence frame and the mic audio track is still not stopped.
  
  When the `stop` boolean indicator set to true, the method will stop the mic audio capture track. The track becomes unusable and when turning on the audio capture track again will require calling `peer.turnOnMic(newTrack)`.
  
  The readme is updated. [See here](https://github.com/inlivedev/inlive-js-sdk/blob/feat/on-off-camera-mic/packages/room/README.md).