### PR TITLE
fix: use no-store cache to prevent storing cache

### DIFF
--- a/packages/room/api/auth.js
+++ b/packages/room/api/auth.js
@@ -45,6 +45,7 @@ export const createAuth = async (userConfig = config) => {
   const response = await fetcher.post('/keys/accesstoken', {
     headers: { Authorization: 'Bearer ' + config.apiKey },
     body: JSON.stringify(body),
+    cache: 'no-store',
   })
 
   const data = response.data || {}


### PR DESCRIPTION
The fetch request to get the access token should not be stored in any form of cache